### PR TITLE
docs(README): Rename renderer.tsx to _renderer.tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ declare module '@hono/react-renderer' {
 }
 ```
 
-The following is an example of `app/routes/renderer.tsx`.
+The following is an example of `app/routes/_renderer.tsx`.
 
 ```tsx
 // app/routes/_renderer.tsx


### PR DESCRIPTION
Just a typo fix. Thanks