### PR TITLE
feat: add support for client component in children

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -45,7 +45,10 @@ export const createClient = async (options?: ClientOptions) => {
             let createChildren = options?.createChildren
             if (!createChildren) {
               const { buildCreateChildrenFn } = await import('./runtime')
-              createChildren = buildCreateChildrenFn(createElement as CreateElement)
+              createChildren = buildCreateChildrenFn(
+                createElement as CreateElement,
+                async (name: string) => (await (FILES[`${root}${name}`] as FileCallback)()).default
+              )
             }
             props.children = await createChildren(
               (maybeTemplate as HTMLTemplateElement).content.childNodes

--- a/test/hono-jsx/app/routes/interaction/children.tsx
+++ b/test/hono-jsx/app/routes/interaction/children.tsx
@@ -9,12 +9,20 @@ export default function Interaction() {
     <>
       <Counter id='sync'>
         <div>
-          <h3 id="sync-header">Sync</h3>
-          <span data-content="Sync child">Sync child</span>
+          <h3 id='sync-header'>Sync</h3>
+          <span data-content='Sync child'>Sync child</span>
         </div>
       </Counter>
       <Counter id='async' initial={2}>
         <AsyncChild />
+      </Counter>
+      <Counter id='nest' initial={10}>
+        <div>Child Counter</div>
+        <Counter id='child' initial={12}>
+          <div>
+            <h3 id='child-header'>Child</h3>
+          </div>
+        </Counter>
       </Counter>
     </>
   )

--- a/test/hono-jsx/e2e.test.ts
+++ b/test/hono-jsx/e2e.test.ts
@@ -34,6 +34,19 @@ test('children - async', async ({ page }) => {
   await container.getByText('Async child').click()
 })
 
+test('children - nest', async ({ page }) => {
+  await page.goto('/interaction/children')
+  await page.waitForSelector('body[data-client-loaded]')
+
+  const container = page.locator('id=nest')
+  await container.locator('button').first().click()
+  await container.getByText('Count: 11').click()
+
+  const childContainer = page.locator('id=child')
+  await childContainer.locator('button').click()
+  await childContainer.getByText('Count: 13').click()
+})
+
 test('suspense', async ({ page }) => {
   await page.goto('/interaction/suspense', { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('body[data-client-loaded]')


### PR DESCRIPTION
fixes #74

### What is this?

https://github.com/honojs/honox/pull/56 allows the insertion of server components as children. In this PR, in addition to that, if a client component is included as a child, it will be hydrate as a client component.

### What will this allow us to do?

First, `useReducer` needs to be added by the following PR.
https://github.com/honojs/hono/pull/2197

After that, the pattern using `useReducer()` and "Context API" introduced in the following stackoverflow question can be used to share the state.

https://stackoverflow.com/questions/63687178/sharing-states-between-two-components-with-usereducer

Below is a project that implements this.

https://github.com/usualoma/honox-jsx-children

```ts
import { createRoute } from "honox/factory";
import Producer from "../islands/producer";
import Consumer from "../islands/consumer";

export default createRoute((c) => {
  const name = c.req.query("name") ?? "no name";
  return c.render(
    <div>
      <h1>Hello, {name}!</h1>
      <h2>Producer</h2>
      <Producer/>
      <h2>Consumer</h2>
      <Consumer/>
    </div>,
    { title: name }
  );
});
```


https://github.com/honojs/honox/assets/30598/06f47fbc-40dc-4a17-938d-5e0425d3be06

