### PR TITLE
feat: add createApp without default routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js"
     },
+    "./server/base": {
+      "types": "./dist/server/base.d.ts",
+      "import": "./dist/server/base.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
@@ -68,6 +72,9 @@
       ],
       "server": [
         "./dist/server"
+      ],
+      "server/base": [
+        "./dist/server/base"
       ],
       "client": [
         "./dist/client"

--- a/src/server/base.ts
+++ b/src/server/base.ts
@@ -1,0 +1,1 @@
+export { createApp } from './server.js'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,3 @@
-export { createApp } from './server.js'
+export { createApp } from './with-defaults.js'
 export type { ServerOptions } from './server.js'
 export * from './components/index.js'

--- a/src/server/with-defaults.ts
+++ b/src/server/with-defaults.ts
@@ -1,0 +1,38 @@
+import type { Env } from 'hono'
+import { createApp as baseCreateApp } from './server.js'
+import type { ServerOptions } from './server.js'
+
+export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
+  const newOptions = {
+    root: options?.root ?? '/app/routes',
+    app: options?.app,
+    init: options?.init,
+    NOT_FOUND:
+      options?.NOT_FOUND ??
+      import.meta.glob('/app/routes/**/_404.(ts|tsx)', {
+        eager: true,
+      }),
+    ERROR:
+      options?.ERROR ??
+      import.meta.glob('/app/routes/**/_error.(ts|tsx)', {
+        eager: true,
+      }),
+    RENDERER:
+      options?.RENDERER ??
+      import.meta.glob('/app/routes/**/_renderer.tsx', {
+        eager: true,
+      }),
+    MIDDLEWARE:
+      options?.MIDDLEWARE ??
+      import.meta.glob('/app/routes/**/_middleware.(ts|tsx)', {
+        eager: true,
+      }),
+    ROUTES:
+      options?.ROUTES ??
+      import.meta.glob('/app/routes/**/[!_]*.(ts|tsx|mdx)', {
+        eager: true,
+      }),
+  }
+
+  return baseCreateApp(newOptions)
+}


### PR DESCRIPTION
If the user implementation includes `import { createApp } from "honox/server"`, all routes are included in the bundle by the hardcoded `import.meta.glob`.

Even if the user gives the option of `createApp` to overwrite it, the hardcoded part is still there and will not be removed by DCE.

With this change, `import { createApp } from "honox/server/base"` can be used to bypass the hardcoded parts and control all bundled routes by the options we give.

This change also allows builds that only return dynamic routes from Cloudflare Workers, without unnecessary routes which is already SSGed.
(We still need to work, due to [current `@hono/vite-cloudflare-pages` cannot serve SSGed files](https://github.com/honojs/vite-plugins/blob/551e8801c2450f1723a51318e489a83b95798887/packages/cloudflare-pages/src/entry.ts#L38-L44) )