### PR TITLE
feat: `Script` component supports css

### DIFF
--- a/src/server/components/script.tsx
+++ b/src/server/components/script.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'hono/jsx'
+import type { Child, FC } from 'hono/jsx'
 import type { Manifest } from 'vite'
 import { HasIslands } from './has-islands.js'
 
@@ -27,7 +27,16 @@ export const Script: FC<Options> = async (options) => {
     if (manifest) {
       const scriptInManifest = manifest[src.replace(/^\//, '')]
       if (scriptInManifest) {
-        return (
+        const elements: Child[] = []
+
+        // May make it optional to output CSS or not depending on user feedback.
+        if (scriptInManifest.css) {
+          for (const css of scriptInManifest.css) {
+            elements.push(<link href={css} rel='stylesheet' />)
+          }
+        }
+
+        elements.push(
           <HasIslands>
             <script
               type='module'
@@ -35,6 +44,14 @@ export const Script: FC<Options> = async (options) => {
               src={`/${scriptInManifest.file}`}
             ></script>
           </HasIslands>
+        )
+
+        return (
+          <>
+            {elements.map((element) => {
+              return <>{element}</>
+            })}
+          </>
         )
       }
     }

--- a/test/hono-jsx/app-script/routes/_renderer.tsx
+++ b/test/hono-jsx/app-script/routes/_renderer.tsx
@@ -12,6 +12,7 @@ export default jsxRenderer(
             manifest={{
               'app/client.ts': {
                 file: 'static/client-abc.js',
+                css: ['/static/style.css'],
               },
             }}
           />

--- a/test/hono-jsx/integration.test.ts
+++ b/test/hono-jsx/integration.test.ts
@@ -413,7 +413,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
+        '<html><head><link href="/static/style.css" rel="stylesheet"/><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
       )
     })
   })


### PR DESCRIPTION
Resolves #90

With the `Script` component in this PR, you can import CSS for both development and production easily:

```ts
// app/client.ts
import { createClient } from 'honox/client'
import './style.css' // import `css`

createClient()
```

```tsx
// app/routes/_renderer.tsx
import { jsxRenderer } from 'hono/jsx-renderer'
import { Script } from 'honox/server'

export default jsxRenderer(({ children }) => {
  return (
    <html lang="en">
      <head>
        <meta charset="utf-8" />
        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
        <Script src="/app/client.ts" />
      </head>
      <body>{children}</body>
    </html>
  )
})
```

```ts
// vite.config.ts
import pages from '@hono/vite-cloudflare-pages'
import honox from 'honox/vite'
import client from 'honox/vite/client'
import { defineConfig } from 'vite'

export default defineConfig(({ mode }) => {
  if (mode === 'client') {
    return {
      plugins: [client()]
    }
  } else {
    return {
      plugins: [honox(), pages()]
    }
  }
})
```

Then output HTML:

```html
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8"/>
        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
        <link href="static/client-wNd0jdbA.css" rel="stylesheet"/>
    </head>
    <body>
        <div>
            <h1>Hello!</h1>
        </div>
    </body>
</html>
```