### PR TITLE
feat: exclude *.test.* and *.spec.* files in routes

### DIFF
--- a/src/server/with-defaults.ts
+++ b/src/server/with-defaults.ts
@@ -29,7 +29,7 @@ export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
       }),
     ROUTES:
       options?.ROUTES ??
-      import.meta.glob('/app/routes/**/[!_]*.(ts|tsx|mdx)', {
+      import.meta.glob('/app/routes/**/!(_*|*.test|*.spec).(ts|tsx|mdx)', {
         eager: true,
       }),
   }


### PR DESCRIPTION
Enabled colocated test files in routes by excluding *.test.* and *.spec.* from routing recognition.