### PR TITLE
fix: transform island components on Windows

### DIFF
--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -207,7 +207,7 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
     async load(id) {
       const defaultIsIsland: IsIsland = (id) => {
         const islandDirectoryPath = path.join(root, 'app/islands')
-        return id.startsWith(islandDirectoryPath)
+        return path.resolve(id).startsWith(islandDirectoryPath)
       }
       const matchIslandPath = options?.isIsland ?? defaultIsIsland
       if (!matchIslandPath(id)) {


### PR DESCRIPTION
This PR resolves island components doesn't transform on Windows.

On Windows, island components doesn't transform html correctly.

### Input:
```tsx
import { createRoute } from 'honox/factory'
import Counter from '../../islands/counter'

export default createRoute((c) => {
  return c.render(
    <div>
      <h1>Hello</h1>
      <Counter />
    </div>
  )
})
```

### Output:
```html
<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title></title><script type="module" async="" src="/static/client-UlfpEE_A.js"></script></head><body><div><h1>Hello</h1><div><p>0</p><button>Increment</button></div></div></body></html>
```

### Details:
```ts
const defaultIsIsland: IsIsland = (id) => {
  const islandDirectoryPath = path.join(root, 'app/islands')
  return id.startsWith(islandDirectoryPath)
}
```

`id` and `root` are delimited by '/' on all platforms.
path.join is normalizes to the appropriate file path delimiter per platform.

On Windows, path.join returns path delimited by '\'.
`id.startsWith` will always false because it compares forward slash delimited paths and back slash delimited paths.

This PR adds path delimiter conversion before comparison.