### PR TITLE
chore: fix `vite` path in playwright config

### DIFF
--- a/test/hono-jsx/playwright.config.ts
+++ b/test/hono-jsx/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'bun run vite --port 6173 -c ./vite.config.ts',
+    command: '../../node_modules/vite/bin/vite.js --port 6173 -c ./vite.config.ts',
     port: 6173,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
Fixes `playwright` not running without the `bun` command. It is not smart, but this method is the most universal.