### PR TITLE
feat: enable to put "island" not only in `islands` directory

### DIFF
--- a/mocks/app/routes/directory/_Counter.island.tsx
+++ b/mocks/app/routes/directory/_Counter.island.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from 'hono/jsx'
+import { useState } from 'hono/jsx'
+
+export default function Counter({
+  children,
+  initial = 0,
+  id = '',
+}: PropsWithChildren<{
+  initial?: number
+  id?: string
+}>) {
+  const [count, setCount] = useState(initial)
+  const increment = () => setCount(count + 1)
+  return (
+    <div id={id}>
+      <p>Count: {count}</p>
+      <button onClick={increment}>Increment</button>
+      {children}
+    </div>
+  )
+}

--- a/mocks/app/routes/directory/index.tsx
+++ b/mocks/app/routes/directory/index.tsx
@@ -1,0 +1,5 @@
+import Counter from './_Counter.island'
+
+export default function Interaction() {
+  return <Counter initial={5} />
+}

--- a/mocks/vite.config.ts
+++ b/mocks/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         isIsland: (id) => {
           const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
           const regexp = new RegExp(
-            `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$`
+            `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$`
           )
           return regexp.test(path.resolve(id))
         },

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -28,8 +28,12 @@ export type ClientOptions = {
 }
 
 export const createClient = async (options?: ClientOptions) => {
-  const FILES = options?.ISLAND_FILES ?? import.meta.glob('/app/islands/**/[a-zA-Z0-9[-]+.(tsx|ts)')
-  const root = options?.island_root ?? '/app/islands/'
+  const FILES = options?.ISLAND_FILES ?? {
+    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9[-]+.(tsx|ts)'),
+    ...import.meta.glob('/app/routes/**/_[a-zA-Z0-9[-]+.island.(tsx|ts)'),
+  }
+
+  const root = options?.island_root ?? '/app'
 
   const hydrateComponent: HydrateComponent = async (document) => {
     const filePromises = Object.keys(FILES).map(async (filePath) => {

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -12,7 +12,7 @@ import { IMPORTING_ISLANDS_ID } from '../constants.js'
 const generate = (_generate.default as typeof _generate) ?? _generate
 
 export async function injectImportingIslands(): Promise<Plugin> {
-  const isIslandRegex = new RegExp(/\/islands\//)
+  const isIslandRegex = new RegExp(/(\/islands\/|\_[a-zA-Z0-9[-]+\.island\.[tj]sx$)/)
   const fileRegex = new RegExp(/(routes|_renderer|_error|_404)\/.*\.[tj]sx$/)
   const cache: Record<string, string> = {}
 

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -206,16 +206,16 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
     },
     async load(id) {
       const defaultIsIsland: IsIsland = (id) => {
-        const islandDirectoryPath = path.join(root, 'app/islands')
+        const islandDirectoryPath = path.join(root, 'app')
         return path.resolve(id).startsWith(islandDirectoryPath)
       }
       const matchIslandPath = options?.isIsland ?? defaultIsIsland
       if (!matchIslandPath(id)) {
         return
       }
-      const match = id.match(/\/islands\/(.+?\.tsx)$/)
+      const match = id.match(/(\/islands\/.+?\.tsx$)|(\/routes\/.*\_[a-zA-Z0-9[-]+\.island\.tsx$)/)
       if (match) {
-        const componentName = match[1]
+        const componentName = match[0]
         const contents = await fs.readFile(id, 'utf-8')
         const code = transformJsxTags(contents, componentName)
         if (code) {

--- a/test-e2e/e2e.test.ts
+++ b/test-e2e/e2e.test.ts
@@ -11,6 +11,17 @@ test('test counter', async ({ page }) => {
   await page.getByText('Count: 6').click()
 })
 
+test('test counter - island in the same directory', async ({ page }) => {
+  await page.goto('/directory')
+  await page.waitForSelector('body[data-client-loaded]')
+
+  await page.getByText('Count: 5').click()
+  await page.getByRole('button', { name: 'Increment' }).click({
+    clickCount: 1,
+  })
+  await page.getByText('Count: 6').click()
+})
+
 test('children - sync', async ({ page }) => {
   await page.goto('/interaction/children')
   await page.waitForSelector('body[data-client-loaded]')

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -134,6 +134,16 @@ describe('Basic', () => {
         handler: expect.any(Function),
       },
       {
+        path: '/directory',
+        method: 'GET',
+        handler: expect.any(Function),
+      },
+      {
+        path: '/directory',
+        method: 'GET',
+        handler: expect.any(Function),
+      },
+      {
         path: '/fc',
         method: 'GET',
         handler: expect.any(Function),
@@ -290,7 +300,7 @@ describe('With preserved', () => {
     expect(res.status).toBe(200)
     // hono/jsx escape a single quote to &#39;
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="Counter.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div id=""><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div id=""><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -308,7 +318,7 @@ describe('With preserved', () => {
          <body>
             <div>
                <h1>Nested Island Test</h1>
-               <honox-island component-name="Counter.tsx" data-serialized-props="{}">
+               <honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}">
                   <div id="">
                      <p>Count: 0</p>
                      <button>Increment</button>
@@ -319,6 +329,15 @@ describe('With preserved', () => {
          </body>
       </html>
 `.replace(/\n|\s{2,}/g, '')
+    )
+  })
+
+  it('Should return 200 response - /directory', async () => {
+    const res = await app.request('/directory')
+    expect(res.status).toBe(200)
+    // hono/jsx escape a single quote to &#39;
+    expect(await res.text()).toBe(
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/routes/directory/_Counter.island.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div id=""><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -473,7 +492,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
+        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
       )
     })
 
@@ -481,7 +500,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/classic')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
+        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
       )
     })
   })
@@ -501,7 +520,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><body><main><honox-island component-name="Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" async="" src="/static/client-abc.js"></script></body></html>'
+        '<html><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" async="" src="/static/client-abc.js"></script></body></html>'
       )
     })
   })
@@ -525,7 +544,7 @@ describe('<HasIslands /> Component with path aliases', () => {
     const res = await app.request('/has-islands')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
-      '<html><body><honox-island component-name="Counter.tsx" data-serialized-props="{}"><div>Counter</div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div>Counter</div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -565,7 +584,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/foo')
     expect(res.status).toBe(404)
     expect(await res.text()).toBe(
-      '<html><head><title>Not Found</title></head><body><honox-island component-name="Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title>Not Found</title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -573,7 +592,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/throw_error')
     expect(res.status).toBe(500)
     expect(await res.text()).toBe(
-      '<html><head><title>Internal Server Error</title></head><body><honox-island component-name="Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title>Internal Server Error</title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -581,7 +600,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/nested/post')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
-      '<html><head><title></title></head><body><honox-island component-name="Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><h1>Hello MDX</h1><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title></title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><h1>Hello MDX</h1><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 })

--- a/test-integration/vitest.config.ts
+++ b/test-integration/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       isIsland: (id) => {
         const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
         const regexp = new RegExp(
-          `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$`
+          `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$`
         )
         return regexp.test(path.resolve(id))
       },


### PR DESCRIPTION
Related to #45 

With this PR, you can put an island component in a directory under `/app/routes`, not only the `/app/islands` directory. You should name it with a `_` prefix, like `_counter.island.tsx`.

```
app
├── client.ts
├── global.d.ts
├── islands
│   └── counter.tsx
├── routes
│   ├── directory
│   │   ├── _counter.island.tsx // <--- You can put it here
│   │   └── index.tsx
│   ├── index.tsx
└── server.ts
```

It was inefficient to put Islands in `/app/islands`, which are used only in a certain directory. However, this PR makes it easier to understand the structure by placing Islands in the same directory as the files that use them.
