### PR TITLE
fix: correct routing priority if file name has brackets

### DIFF
--- a/mocks/app-nested-middleware/routes/nested/foo/bar/[id]/index.tsx
+++ b/mocks/app-nested-middleware/routes/nested/foo/bar/[id]/index.tsx
@@ -1,0 +1,3 @@
+export default function Id() {
+  return <h1>Id</h1>
+}

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -63,30 +63,38 @@ describe('sortDirectoriesByDepth', () => {
   it('Should sort directories by the depth', () => {
     expect(
       sortDirectoriesByDepth({
-        '/app/routes': {
+        '/dir': {
           'index.tsx': 'file1',
         },
-        '/app/routes/blog/posts': {
+        '/dir/blog/[id]': {
           'index.tsx': 'file2',
         },
-        '/app/routes/blog': {
+        '/dir/blog/posts': {
           'index.tsx': 'file3',
+        },
+        '/dir/blog': {
+          'index.tsx': 'file4',
         },
       })
-    ).toEqual([
+    ).toStrictEqual([
       {
-        '/app/routes/blog': {
+        '/dir': {
+          'index.tsx': 'file1',
+        },
+      },
+      {
+        '/dir/blog': {
+          'index.tsx': 'file4',
+        },
+      },
+      {
+        '/dir/blog/posts': {
           'index.tsx': 'file3',
         },
       },
       {
-        '/app/routes/blog/posts': {
+        '/dir/blog/[id]': {
           'index.tsx': 'file2',
-        },
-      },
-      {
-        '/app/routes': {
-          'index.tsx': 'file1',
         },
       },
     ])

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -56,11 +56,20 @@ export const groupByDirectory = <T = unknown>(files: Record<string, T>) => {
 }
 
 export const sortDirectoriesByDepth = <T>(directories: Record<string, T>) => {
-  const sortedKeys = Object.keys(directories).sort((a, b) => {
-    const depthA = a.split('/').length
-    const depthB = b.split('/').length
-    return depthA - depthB
-  })
+  const sortedKeys = Object.keys(directories)
+    .sort((a, b) => {
+      const depthA = a.split('/').length
+      const depthB = b.split('/').length
+      return depthA - depthB
+    })
+    .sort((a, b) => {
+      const depthA = a.split('/').length
+      const depthB = b.split('/').length
+      if (depthA === depthB) {
+        return b.localeCompare(a)
+      }
+      return 1
+    })
 
   // if we have root routes, make sure they are registered last
   if (sortedKeys.find((x) => /.*\/routes$/.test(x))) {

--- a/test-integration/api.test.ts
+++ b/test-integration/api.test.ts
@@ -60,7 +60,7 @@ describe('Basic', () => {
     ]
 
     expect(app.routes).toHaveLength(routes.length)
-    expect(app.routes).toEqual(routes)
+    expect(app.routes).toEqual(expect.arrayContaining(routes))
   })
 
   it('Should return 200 response - / with a Powered By header', async () => {

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -451,6 +451,14 @@ describe('Nested Middleware', () => {
     expect(res.headers.get('bar')).toEqual('bar')
     expect(res.headers.get('baz')).toEqual('baz')
   })
+  it('/nested/foo/bar/123', async () => {
+    const res = await app.request('/nested/foo/bar/123')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('root')).toEqual('root')
+    expect(res.headers.get('root2')).toEqual('root2')
+    expect(res.headers.get('foo')).toEqual('foo')
+    expect(res.headers.get('bar')).toEqual('bar')
+  })
 })
 
 describe('<Script /> component', () => {


### PR DESCRIPTION
Fixed a problem if the path has brackets overriding other directory paths in the same hierarchy.
