### PR TITLE
fix: check it should add `insideIslandSuffix` or not

### DIFF
--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -229,7 +229,10 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
     async resolveId(source, importer) {
       const resolution = await this.resolve(source, importer)
       if (resolution && importer && getIslandComponentName(root, importer, options)) {
-        return resolution.id + insideIslandSuffix
+        // Check if it should add a suffix to that file.
+        if (getIslandComponentName(root, resolution.id, options)) {
+          return resolution.id + insideIslandSuffix
+        }
       }
     },
     async load(id) {


### PR DESCRIPTION
Fixes #152

It's difficult to write tests. Skipping it right now.