### PR TITLE
feat: `Script` and `HasIsland` available at multiple runtimes by replacing renderer source

### DIFF
--- a/src/server/components/has-islands.tsx
+++ b/src/server/components/has-islands.tsx
@@ -1,8 +1,8 @@
-import type { FC } from 'hono/jsx'
 import { useRequestContext } from 'hono/jsx-renderer'
 import { IMPORTING_ISLANDS_ID } from '../../constants.js'
 
-export const HasIslands: FC = ({ children }) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const HasIslands = ({ children }: { children: any }): any => {
   const c = useRequestContext()
   return <>{c.get(IMPORTING_ISLANDS_ID) ? children : <></>}</>
 }

--- a/src/server/components/script.tsx
+++ b/src/server/components/script.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'hono/jsx'
 import type { Manifest } from 'vite'
 import { HasIslands } from './has-islands.js'
 
@@ -10,7 +9,8 @@ type Options = {
   nonce?: string
 }
 
-export const Script: FC<Options> = async (options) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const Script = (options: Options): any => {
   const src = options.src
   if (options.prod ?? import.meta.env.PROD) {
     let manifest: Manifest | undefined = options.manifest

--- a/src/vite/island-components.test.ts
+++ b/src/vite/island-components.test.ts
@@ -244,4 +244,43 @@ describe('options', () => {
       expect(res.code).toMatch(/'react'/)
     })
   })
+
+  describe('rendererImportSource', () => {
+    // get full path of honox-island.tsx
+    const component = path
+      .resolve(__dirname, '../server/components/has-islands.tsx')
+      // replace backslashes for Windows
+      .replace(/\\/g, '/')
+
+    // prettier-ignore
+    it('use \'hono/jsx\' by default', async () => {
+      const plugin = islandComponents()
+      await (plugin.configResolved as Function)({ root: 'root' })
+      const res = await (plugin.load as Function)(component)
+      expect(res.code).toMatch(/'hono\/jsx-renderer'/)
+      expect(res.code).not.toMatch(/'@hono\/react-renderer'/)
+    })
+
+    // prettier-ignore
+    it('enable to specify \'@hono/react-renderer\'', async () => {
+      const plugin = islandComponents({
+        rendererImportSource: '@hono/react-renderer',
+      })
+      await (plugin.configResolved as Function)({ root: 'root' })
+      const res = await (plugin.load as Function)(component)
+      expect(res.code).not.toMatch(/'hono\/jsx-renderer'/)
+      expect(res.code).toMatch(/'@hono\/react-renderer'/)
+    })
+
+    // prettier-ignore
+    it('implicitly set from reactApiImportSource', async () => {
+      const plugin = islandComponents({
+        reactApiImportSource: 'react',
+      })
+      await (plugin.configResolved as Function)({ root: 'root' })
+      const res = await (plugin.load as Function)(component)
+      expect(res.code).not.toMatch(/'hono\/jsx-renderer'/)
+      expect(res.code).toMatch(/'@hono\/react-renderer'/)
+    })
+  })
 })

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -244,7 +244,7 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
     },
 
     async load(id) {
-      if (/\/honox\/.*?\/vite\/components\//.test(id)) {
+      if (/\/honox\/.*?\/(?:server|vite)\/components\//.test(id)) {
         if (!reactApiImportSource) {
           return
         }


### PR DESCRIPTION
I believe that runtime compatibility has been solved by the approach of rewriting the import statement ( like #161 ). 
The challenge now is how to provide a compatible useRequestContext.

The approach tried in #168, using AsyncLocalStorage, is a wholly runtime-independent and clean method, but 
@yusukebe's research has shown that it may cause poor DX in Cloudflare Pages, so it is better not to use it.

### So what do we do now?

Although relying on the renderer implementation is not clean (compared to AsyncLocalStorage), realistically, the renderer used in honox is `hono/jsx-renderer` or `@hono/${jsxImportSource}-renderer`, so replacing this would provide multi-runtime support.