### PR TITLE
fix(windows): failed to build honox on Windows

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,6 +2,7 @@ import { glob } from 'glob'
 import { defineConfig } from 'tsup'
 
 const entryPoints = glob.sync('./src/**/*.+(ts|tsx|json)', {
+  posix: true,
   ignore: ['./src/**/*.test.+(ts|tsx)'],
 })
 


### PR DESCRIPTION
On Windows, could not build HonoX as shown below.

```bash
$ ❯ bun run build
$ tsup && publint
Cannot find src\types.ts,src\index.ts,src\constants.ts,src\vite\restart-on-add-unlink.ts,src\vite\island-components.ts,src\vite\island-components.test.ts,src\vite\inject-importing-islands.ts,src\vite\index.ts,src\vite\client.ts,src\vite\components\index.ts,src\vite\components\honox-island.tsx,src\utils\file.ts,src\utils\file.test.ts,src\server\with-defaults.ts,src\server\server.ts,src\server\index.ts,src\server\base.ts,src\server\components\script.tsx,src\server\components\index.ts,src\server\components\has-islands.tsx,src\factory\index.ts,src\factory\factory.ts,src\client\runtime.ts,src\client\index.ts,src\client\client.ts
error: script "build" exited with code 1
```

This PR enables builds by unifying path delimiters.
After this PR:

```bash
$ ❯ bun run build
$ tsup && publint
CLI Building entry: src/types.ts, src/index.ts, src/constants.ts, src/vite/restart-on-add-unlink.ts, src/vite/island-components.ts, src/vite/island-components.test.ts, src/vite/inject-importing-islands.ts, src/vite/index.ts, src/vite/client.ts, src/vite/components/index.ts, src/vite/components/honox-island.tsx, src/utils/file.ts, src/utils/file.test.ts, src/server/with-defaults.ts, src/server/server.ts, src/server/index.ts, src/server/base.ts, src/server/components/script.tsx, src/server/components/index.ts, src/server/components/has-islands.tsx, src/factory/index.ts, src/factory/factory.ts, src/client/runtime.ts, src/client/index.ts, src/client/client.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.0.2
CLI Using tsup config: C:\Users\natsuneko\ghq\github.com\mika-f\honox\tsup.config.ts
CLI Target: es2022
ESM Build start
ESM dist\types.js                         0 B
ESM dist\index.js                         0 B
ESM dist\vite\restart-on-add-unlink.js    368.00 B
ESM dist\constants.js                     362.00 B
ESM dist\vite\island-components.js        7.95 KB
ESM dist\vite\island-components.test.js   8.74 KB
ESM dist\vite\index.js                    1.22 KB
ESM dist\vite\components\index.js         75.00 B
ESM dist\vite\client.js                   613.00 B
ESM dist\vite\inject-importing-islands.js 2.22 KB
ESM dist\utils\file.js                    2.44 KB
ESM dist\vite\components\honox-island.js  1.76 KB
ESM dist\utils\file.test.js               3.83 KB
ESM dist\server\with-defaults.js          898.00 B
ESM dist\server\server.js                 5.34 KB
ESM dist\server\components\index.js       120.00 B
ESM dist\server\components\script.js      1.14 KB
ESM dist\server\index.js                  111.00 B
ESM dist\server\base.js                   65.00 B
ESM dist\factory\factory.js               243.00 B
ESM dist\client\runtime.js                4.81 KB
ESM dist\server\components\has-islands.js 398.00 B
ESM dist\client\index.js                  71.00 B
ESM dist\factory\index.js                 96.00 B
ESM dist\client\client.js                 2.88 KB
ESM ⚡️ Build success in 39ms
DTS Build start
DTS ⚡️ Build success in 5490ms
DTS dist\server\index.d.ts                  296.00 B
DTS dist\server\components\index.d.ts       119.00 B
DTS dist\index.d.ts                         13.00 B
DTS dist\vite\restart-on-add-unlink.d.ts    111.00 B
DTS dist\vite\inject-importing-islands.d.ts 128.00 B
DTS dist\vite\index.d.ts                    618.00 B
DTS dist\vite\island-components.d.ts        422.00 B
DTS dist\vite\client.d.ts                   244.00 B
DTS dist\utils\file.d.ts                    537.00 B
DTS dist\server\with-defaults.d.ts          1.46 KB
DTS dist\constants.d.ts                     392.00 B
DTS dist\server\components\script.d.ts      243.00 B
DTS dist\server\components\has-islands.d.ts 86.00 B
DTS dist\client\runtime.d.ts                437.00 B
DTS dist\types.d.ts                         505.00 B
DTS dist\vite\components\honox-island.d.ts  226.00 B
DTS dist\server\server.d.ts                 1.60 KB
DTS dist\factory\factory.d.ts               7.50 KB
DTS dist\client\client.d.ts                 600.00 B
DTS dist\vite\island-components.test.d.ts   13.00 B
DTS dist\utils\file.test.d.ts               13.00 B
DTS dist\vite\components\index.d.ts         49.00 B
DTS dist\server\base.d.ts                   103.00 B
DTS dist\factory\index.d.ts                 92.00 B
DTS dist\client\index.d.ts                  81.00 B
honox lint results:
All good!
```