### PR TITLE
feat: enable placing islands anywhere

### DIFF
--- a/mocks/app/components/$counter.tsx
+++ b/mocks/app/components/$counter.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from 'hono/jsx'
+import { useState } from 'hono/jsx'
+
+export default function Counter({
+  children,
+  initial = 0,
+}: PropsWithChildren<{
+  initial?: number
+}>) {
+  const [count, setCount] = useState(initial)
+  const increment = () => setCount(count + 1)
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={increment}>Increment</button>
+      {children}
+    </div>
+  )
+}

--- a/mocks/app/routes/interaction/anywhere.tsx
+++ b/mocks/app/routes/interaction/anywhere.tsx
@@ -1,0 +1,9 @@
+import Counter from '../../components/$counter'
+
+export default function Interaction() {
+  return (
+    <>
+      <Counter initial={5} />
+    </>
+  )
+}

--- a/mocks/vite.config.ts
+++ b/mocks/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
         isIsland: (id) => {
           const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
           const regexp = new RegExp(
-            `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$`
+            `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]components[\\\\/].*\\$.+\.tsx?$`
           )
           return regexp.test(path.resolve(id))
         },

--- a/mocks/vite.config.ts
+++ b/mocks/vite.config.ts
@@ -3,8 +3,6 @@ import mdx from '@mdx-js/rollup'
 import { defineConfig } from 'vite'
 import honox from '../src/vite'
 
-const root = './'
-
 export default defineConfig({
   resolve: {
     alias: {
@@ -14,15 +12,6 @@ export default defineConfig({
   plugins: [
     honox({
       entry: './app/server.ts',
-      islandComponents: {
-        isIsland: (id) => {
-          const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
-          const regexp = new RegExp(
-            `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]components[\\\\/].*\\$.+\.tsx?$`
-          )
-          return regexp.test(path.resolve(id))
-        },
-      },
     }),
     mdx({
       jsxImportSource: 'hono/jsx',

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -29,6 +29,9 @@ export type ClientOptions = {
    */
   triggerHydration?: TriggerHydration
   ISLAND_FILES?: Record<string, () => Promise<unknown>>
+  /**
+   * @deprecated
+   */
   island_root?: string
 }
 
@@ -39,11 +42,9 @@ export const createClient = async (options?: ClientOptions) => {
     ...import.meta.glob('/app/**/$[a-zA-Z0-9-]+.(tsx|ts)'),
   }
 
-  const root = options?.island_root ?? '/app'
-
   const hydrateComponent: HydrateComponent = async (document) => {
     const filePromises = Object.keys(FILES).map(async (filePath) => {
-      const componentName = filePath.replace(root, '')
+      const componentName = filePath
       const elements = document.querySelectorAll(
         `[${COMPONENT_NAME}="${componentName}"]:not([data-hono-hydrated])`
       )
@@ -74,7 +75,7 @@ export const createClient = async (options?: ClientOptions) => {
               const { buildCreateChildrenFn } = await import('./runtime')
               createChildren = buildCreateChildrenFn(
                 createElement as CreateElement,
-                async (name: string) => (await (FILES[`${root}${name}`] as FileCallback)()).default
+                async (name: string) => (await (FILES[`${name}`] as FileCallback)()).default
               )
             }
             props[propKey] = await createChildren(

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -34,8 +34,9 @@ export type ClientOptions = {
 
 export const createClient = async (options?: ClientOptions) => {
   const FILES = options?.ISLAND_FILES ?? {
-    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9[-]+.(tsx|ts)'),
-    ...import.meta.glob('/app/routes/**/_[a-zA-Z0-9[-]+.island.(tsx|ts)'),
+    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9-]+.(tsx|ts)'),
+    ...import.meta.glob('/app/**/_[a-zA-Z0-9-]+.island.(tsx|ts)'),
+    ...import.meta.glob('/app/**/$[a-zA-Z0-9-]+.(tsx|ts)'),
   }
 
   const root = options?.island_root ?? '/app'

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -37,9 +37,9 @@ export type ClientOptions = {
 
 export const createClient = async (options?: ClientOptions) => {
   const FILES = options?.ISLAND_FILES ?? {
-    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9-]+.(tsx|ts)'),
-    ...import.meta.glob('/app/**/_[a-zA-Z0-9-]+.island.(tsx|ts)'),
-    ...import.meta.glob('/app/**/$[a-zA-Z0-9-]+.(tsx|ts)'),
+    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9-]+.tsx'),
+    ...import.meta.glob('/app/**/_[a-zA-Z0-9-]+.island.tsx'),
+    ...import.meta.glob('/app/**/$[a-zA-Z0-9-]+.tsx'),
   }
 
   const hydrateComponent: HydrateComponent = async (document) => {

--- a/src/vite/island-components.test.ts
+++ b/src/vite/island-components.test.ts
@@ -1,44 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { matchIslandComponentId, transformJsxTags, islandComponents } from './island-components'
-
-describe('matchIslandComponentId', () => {
-  describe('match', () => {
-    const paths = [
-      '/islands/counter.tsx',
-      '/islands/directory/counter.tsx',
-      '/routes/$counter.tsx',
-      '/routes/directory/$counter.tsx',
-      '/routes/_counter.island.tsx',
-      '/routes/directory/_counter.island.tsx',
-    ]
-
-    paths.forEach((path) => {
-      it(`Should match ${path}`, () => {
-        const match = matchIslandComponentId(path)
-        expect(match).not.toBeNull()
-        expect(match![0]).toBe(path)
-      })
-    })
-  })
-
-  describe('not match', () => {
-    const paths = [
-      '/routes/directory/component.tsx',
-      '/routes/directory/foo$component.tsx',
-      '/routes/directory/foo_component.island.tsx',
-      '/routes/directory/component.island.tsx',
-    ]
-
-    paths.forEach((path) => {
-      it(`Should not match ${path}`, () => {
-        const match = matchIslandComponentId(path)
-        expect(match).toBeNull()
-      })
-    })
-  })
-})
+import { transformJsxTags, islandComponents } from './island-components.js'
 
 describe('transformJsxTags', () => {
   it('Should add component-wrapper and component-name attribute', () => {

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -252,7 +252,7 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
         return
       }
 
-      const pathFromAppPath = id.replace(appPath, '')
+      const pathFromAppPath = '/' + path.relative(appPath, id).replace(/\\/g, '/')
       const match = matchIslandComponentId(pathFromAppPath)
       if (match) {
         const componentName = match[0]

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -200,20 +200,22 @@ export const transformJsxTags = (contents: string, componentName: string) => {
 
 type IsIsland = (id: string) => boolean
 export type IslandComponentsOptions = {
+  /**
+   * @deprecated
+   */
   isIsland?: IsIsland
-  appDir?: string
+  islandDir?: string
   reactApiImportSource?: string
 }
 
 export function islandComponents(options?: IslandComponentsOptions): Plugin {
   let root = ''
   let reactApiImportSource = options?.reactApiImportSource
-  let appPath = ''
+  const islandDir = options?.islandDir ?? '/app/islands'
   return {
     name: 'transform-island-components',
     configResolved: async (config) => {
       root = config.root
-      appPath = path.join(root, options?.appDir ?? '/app')
 
       if (!reactApiImportSource) {
         const tsConfigPath = path.resolve(process.cwd(), 'tsconfig.json')
@@ -243,17 +245,8 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
         }
       }
 
-      const defaultIsIsland: IsIsland = (id) => {
-        return path.resolve(id).startsWith(appPath)
-      }
-
-      const matchIslandPath = options?.isIsland ?? defaultIsIsland
-      if (!matchIslandPath(id)) {
-        return
-      }
-
-      const pathFromAppPath = '/' + path.relative(appPath, id).replace(/\\/g, '/')
-      const match = matchIslandComponentId(pathFromAppPath)
+      const rootPath = '/' + path.relative(root, id).replace(/\\/g, '/')
+      const match = matchIslandComponentId(rootPath, islandDir)
       if (match) {
         const componentName = match[0]
         const contents = await fs.readFile(id, 'utf-8')

--- a/src/vite/utils/path.test.ts
+++ b/src/vite/utils/path.test.ts
@@ -1,0 +1,42 @@
+import { matchIslandComponentId } from './path'
+
+describe('matchIslandComponentId', () => {
+  describe('match', () => {
+    const paths = [
+      '/islands/counter.tsx',
+      '/islands/directory/counter.tsx',
+      '/routes/$counter.tsx',
+      '/routes/directory/$counter.tsx',
+      '/routes/_counter.island.tsx',
+      '/routes/directory/_counter.island.tsx',
+      '/$counter.tsx',
+      '/directory/$counter.tsx',
+      '/_counter.island.tsx',
+      '/directory/_counter.island.tsx',
+    ]
+
+    paths.forEach((path) => {
+      it(`Should match ${path}`, () => {
+        const match = matchIslandComponentId(path)
+        expect(match).not.toBeNull()
+        expect(match![0]).toBe(path)
+      })
+    })
+  })
+
+  describe('not match', () => {
+    const paths = [
+      '/routes/directory/component.tsx',
+      '/routes/directory/foo$component.tsx',
+      '/routes/directory/foo_component.island.tsx',
+      '/routes/directory/component.island.tsx',
+    ]
+
+    paths.forEach((path) => {
+      it(`Should not match ${path}`, () => {
+        const match = matchIslandComponentId(path)
+        expect(match).toBeNull()
+      })
+    })
+  })
+})

--- a/src/vite/utils/path.test.ts
+++ b/src/vite/utils/path.test.ts
@@ -30,11 +30,23 @@ describe('matchIslandComponentId', () => {
       '/routes/directory/foo$component.tsx',
       '/routes/directory/foo_component.island.tsx',
       '/routes/directory/component.island.tsx',
+      '/directory/islands/component.tsx',
     ]
 
     paths.forEach((path) => {
       it(`Should not match ${path}`, () => {
         const match = matchIslandComponentId(path)
+        expect(match).toBeNull()
+      })
+    })
+  })
+
+  describe('not match - with `islandDir`', () => {
+    const paths = ['/islands/component.tsx']
+
+    paths.forEach((path) => {
+      it(`Should not match ${path}`, () => {
+        const match = matchIslandComponentId(path, '/directory/islands')
         expect(match).toBeNull()
       })
     })

--- a/src/vite/utils/path.ts
+++ b/src/vite/utils/path.ts
@@ -1,0 +1,27 @@
+/**
+ * Check if the name is a valid component name
+ *
+ * @param name - The name to check
+ * @returns true if the name is a valid component name
+ * @example
+ * isComponentName('Badge') // true
+ * isComponentName('BadgeComponent') // true
+ * isComponentName('badge') // false
+ * isComponentName('MIN') // false
+ * isComponentName('Badge_Component') // false
+ */
+export function isComponentName(name: string) {
+  return /^[A-Z][A-Z0-9]*[a-z][A-Za-z0-9]*$/.test(name)
+}
+
+/**
+ * Matches when id is the filename of Island component
+ *
+ * @param id - The id to match
+ * @returns The result object if id is matched or null
+ */
+export function matchIslandComponentId(id: string) {
+  return id.match(
+    /\/islands\/.+?\.tsx$|.*\/(?:\_[a-zA-Z0-9-]+\.island\.tsx$|\$[a-zA-Z0-9-]+\.tsx$)/
+  )
+}

--- a/src/vite/utils/path.ts
+++ b/src/vite/utils/path.ts
@@ -20,8 +20,9 @@ export function isComponentName(name: string) {
  * @param id - The id to match
  * @returns The result object if id is matched or null
  */
-export function matchIslandComponentId(id: string) {
-  return id.match(
-    /\/islands\/.+?\.tsx$|.*\/(?:\_[a-zA-Z0-9-]+\.island\.tsx$|\$[a-zA-Z0-9-]+\.tsx$)/
+export function matchIslandComponentId(id: string, islandDir: string = '/islands') {
+  const regExp = new RegExp(
+    `^${islandDir}\/.+?\.tsx$|.*\/(?:\_[a-zA-Z0-9-]+\.island\.tsx$|\\\$[a-zA-Z0-9-]+\.tsx$)`
   )
+  return id.match(regExp)
 }

--- a/test-e2e/e2e.test.ts
+++ b/test-e2e/e2e.test.ts
@@ -28,13 +28,13 @@ test('test counter - island in the same directory', async ({ page }) => {
   await page.getByRole('button', { name: 'UnderScore Increment' }).click({
     clickCount: 1,
   })
-  await page.getByText('Count: 6').click()
+  await page.getByText('UnderScoreCount: 6').click()
 
   await page.getByText('DollarCount: 5').click()
   await page.getByRole('button', { name: 'Dollar Increment' }).click({
     clickCount: 1,
   })
-  await page.getByText('Count: 6').click()
+  await page.getByText('DollarCount: 6').click()
 })
 
 test('test counter - island in anywhere', async ({ page }) => {

--- a/test-e2e/e2e.test.ts
+++ b/test-e2e/e2e.test.ts
@@ -37,6 +37,17 @@ test('test counter - island in the same directory', async ({ page }) => {
   await page.getByText('Count: 6').click()
 })
 
+test('test counter - island in anywhere', async ({ page }) => {
+  await page.goto('/interaction/anywhere')
+  await page.waitForSelector('body[data-client-loaded]')
+
+  await page.getByText('Count: 5').click()
+  await page.getByRole('button', { name: 'Increment' }).click({
+    clickCount: 1,
+  })
+  await page.getByText('Count: 6').click()
+})
+
 test('children - sync', async ({ page }) => {
   await page.goto('/interaction/children')
   await page.waitForSelector('body[data-client-loaded]')

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -79,6 +79,16 @@ describe('Basic', () => {
         handler: expect.any(Function),
       },
       {
+        path: '/interaction/anywhere',
+        method: 'GET',
+        handler: expect.any(Function),
+      },
+      {
+        path: '/interaction/anywhere',
+        method: 'GET',
+        handler: expect.any(Function),
+      },
+      {
         path: '/interaction/children',
         method: 'GET',
         handler: expect.any(Function),
@@ -309,6 +319,14 @@ describe('With preserved', () => {
     )
   })
 
+  it('Should return 200 response - /interaction/anywhere', async () => {
+    const res = await app.request('/interaction/anywhere')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/app/components/$counter.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+    )
+  })
+
   it('Should return 200 response - /interaction/nested', async () => {
     const res = await app.request('/interaction/nested')
     expect(res.status).toBe(200)
@@ -343,7 +361,7 @@ describe('With preserved', () => {
     expect(res.status).toBe(200)
     // hono/jsx escape a single quote to &#39;
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/routes/directory/_Counter.island.tsx" data-serialized-props="{&quot;id&quot;:&quot;under-score&quot;,&quot;initial&quot;:5}"><div id="under-score"><p>UnderScoreCount: 5</p><button>UnderScore Increment</button></div></honox-island><honox-island component-name="/routes/directory/$counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;dollar&quot;,&quot;initial&quot;:5}"><div id="dollar"><p>DollarCount: 5</p><button>Dollar Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/app/routes/directory/_Counter.island.tsx" data-serialized-props="{&quot;id&quot;:&quot;under-score&quot;,&quot;initial&quot;:5}"><div id="under-score"><p>UnderScoreCount: 5</p><button>UnderScore Increment</button></div></honox-island><honox-island component-name="/app/routes/directory/$counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;dollar&quot;,&quot;initial&quot;:5}"><div id="dollar"><p>DollarCount: 5</p><button>Dollar Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -315,7 +315,7 @@ describe('With preserved', () => {
     expect(res.status).toBe(200)
     // hono/jsx escape a single quote to &#39;
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:5,&quot;id&quot;:&quot;first&quot;}"><div id="first"><p>Counter</p><p>Count: 5</p><button>Increment</button></div></honox-island><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:10}"><div id=""><p>Counter</p><p>Count: 10</p><button>Increment</button><div id=""><p>Counter</p><p>Count: 15</p><button>Increment</button></div></div><template data-hono-template="children"><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:15}"><div id=""><honox-island component-name="/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 15</p><button>Increment</button></div></honox-island></template></honox-island><honox-island component-name="/islands/NamedCounter.tsx" component-export="NamedCounter" data-serialized-props="{&quot;initial&quot;:30,&quot;id&quot;:&quot;named&quot;}"><div id="named"><p>Counter</p><p>Count: 30</p><button>Increment</button></div></honox-island><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:20}"><div id=""><p>Counter</p><p>Count: 20</p><button>Increment</button><div id=""><p>Counter</p><p>Count: 30</p><button>Increment</button></div><div><div id="slot"><p>Counter</p><p>Count: 25</p><button>Increment</button></div></div></div><template data-hono-template="slot"><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;slot&quot;,&quot;initial&quot;:25}"><div id="slot"><honox-island component-name="/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 25</p><button>Increment</button></div></honox-island></template><template data-hono-template="children"><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:30}"><div id=""><honox-island component-name="/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 30</p><button>Increment</button></div></honox-island></template></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:5,&quot;id&quot;:&quot;first&quot;}"><div id="first"><p>Counter</p><p>Count: 5</p><button>Increment</button></div></honox-island><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:10}"><div id=""><p>Counter</p><p>Count: 10</p><button>Increment</button><div id=""><p>Counter</p><p>Count: 15</p><button>Increment</button></div></div><template data-hono-template="children"><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:15}"><div id=""><honox-island component-name="/mocks/app/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 15</p><button>Increment</button></div></honox-island></template></honox-island><honox-island component-name="/mocks/app/islands/NamedCounter.tsx" component-export="NamedCounter" data-serialized-props="{&quot;initial&quot;:30,&quot;id&quot;:&quot;named&quot;}"><div id="named"><p>Counter</p><p>Count: 30</p><button>Increment</button></div></honox-island><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:20}"><div id=""><p>Counter</p><p>Count: 20</p><button>Increment</button><div id=""><p>Counter</p><p>Count: 30</p><button>Increment</button></div><div><div id="slot"><p>Counter</p><p>Count: 25</p><button>Increment</button></div></div></div><template data-hono-template="slot"><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;slot&quot;,&quot;initial&quot;:25}"><div id="slot"><honox-island component-name="/mocks/app/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 25</p><button>Increment</button></div></honox-island></template><template data-hono-template="children"><honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{&quot;initial&quot;:30}"><div id=""><honox-island component-name="/mocks/app/islands/Badge.tsx" data-serialized-props="{&quot;name&quot;:&quot;Counter&quot;}"><p>Counter</p></honox-island><p>Count: 30</p><button>Increment</button></div></honox-island></template></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -323,7 +323,7 @@ describe('With preserved', () => {
     const res = await app.request('/interaction/anywhere')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/app/components/$counter.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/mocks/app/components/$counter.tsx" data-serialized-props="{&quot;initial&quot;:5}"><div><p>Count: 5</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -341,7 +341,7 @@ describe('With preserved', () => {
          <body>
             <div>
                <h1>Nested Island Test</h1>
-               <honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}">
+               <honox-island component-name="/mocks/app/islands/Counter.tsx" data-serialized-props="{}">
                   <div id="">
                      <p>Counter</p>
                      <p>Count: 0</p>
@@ -361,7 +361,7 @@ describe('With preserved', () => {
     expect(res.status).toBe(200)
     // hono/jsx escape a single quote to &#39;
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/app/routes/directory/_Counter.island.tsx" data-serialized-props="{&quot;id&quot;:&quot;under-score&quot;,&quot;initial&quot;:5}"><div id="under-score"><p>UnderScoreCount: 5</p><button>UnderScore Increment</button></div></honox-island><honox-island component-name="/app/routes/directory/$counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;dollar&quot;,&quot;initial&quot;:5}"><div id="dollar"><p>DollarCount: 5</p><button>Dollar Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<!DOCTYPE html><html><head><title></title></head><body><honox-island component-name="/mocks/app/routes/directory/_Counter.island.tsx" data-serialized-props="{&quot;id&quot;:&quot;under-score&quot;,&quot;initial&quot;:5}"><div id="under-score"><p>UnderScoreCount: 5</p><button>UnderScore Increment</button></div></honox-island><honox-island component-name="/mocks/app/routes/directory/$counter.tsx" data-serialized-props="{&quot;id&quot;:&quot;dollar&quot;,&quot;initial&quot;:5}"><div id="dollar"><p>DollarCount: 5</p><button>Dollar Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -529,7 +529,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
+        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/mocks/app-script/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
       )
     })
 
@@ -537,7 +537,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/classic')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
+        '<html><head><script type="module" src="/static/client-abc.js"></script></head><body><main><honox-island component-name="/mocks/app-script/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main></body></html>'
       )
     })
   })
@@ -557,7 +557,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" async="" src="/static/client-abc.js"></script></body></html>'
+        '<html><body><main><honox-island component-name="/mocks/app-script/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" async="" src="/static/client-abc.js"></script></body></html>'
       )
     })
   })
@@ -577,7 +577,7 @@ describe('<Script /> component', () => {
       const res = await app.request('/')
       expect(res.status).toBe(200)
       expect(await res.text()).toBe(
-        '<html><body><main><honox-island component-name="/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" src="/static/client-abc.js" nonce="hono"></script></body></html>'
+        '<html><body><main><honox-island component-name="/mocks/app-script/islands/Component.tsx" data-serialized-props="{}"><p>Component</p></honox-island></main><script type="module" src="/static/client-abc.js" nonce="hono"></script></body></html>'
       )
     })
   })
@@ -601,7 +601,7 @@ describe('<HasIslands /> Component with path aliases', () => {
     const res = await app.request('/has-islands')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
-      '<html><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div>Counter</div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><body><honox-island component-name="/mocks/app-alias/islands/Counter.tsx" data-serialized-props="{}"><div>Counter</div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -641,7 +641,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/foo')
     expect(res.status).toBe(404)
     expect(await res.text()).toBe(
-      '<html><head><title>Not Found</title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title>Not Found</title></head><body><honox-island component-name="/mocks/app-islands-in-preserved/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -649,7 +649,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/throw_error')
     expect(res.status).toBe(500)
     expect(await res.text()).toBe(
-      '<html><head><title>Internal Server Error</title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title>Internal Server Error</title></head><body><honox-island component-name="/mocks/app-islands-in-preserved/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 
@@ -657,7 +657,7 @@ describe('Island Components with Preserved Files', () => {
     const res = await app.request('/nested/post')
     expect(res.status).toBe(200)
     expect(await res.text()).toBe(
-      '<html><head><title></title></head><body><honox-island component-name="/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><h1>Hello MDX</h1><script type="module" async="" src="/app/client.ts"></script></body></html>'
+      '<html><head><title></title></head><body><honox-island component-name="/mocks/app-islands-in-preserved/islands/Counter.tsx" data-serialized-props="{}"><div id=""><p>Count: 0</p><button>Increment</button></div></honox-island><h1>Hello MDX</h1><script type="module" async="" src="/app/client.ts"></script></body></html>'
     )
   })
 })

--- a/test-integration/vitest.config.ts
+++ b/test-integration/vitest.config.ts
@@ -4,8 +4,8 @@ import { defineConfig } from 'vitest/config'
 import { injectImportingIslands } from '../src/vite/inject-importing-islands'
 import { islandComponents } from '../src/vite/island-components'
 
-const root = './mocks'
 const appDir = '/mocks'
+const islandDir = '/mocks/[^/]+/islands'
 
 export default defineConfig({
   resolve: {
@@ -16,16 +16,10 @@ export default defineConfig({
   },
   plugins: [
     islandComponents({
-      isIsland: (id) => {
-        const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
-        const regexp = new RegExp(
-          `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].*\\$.+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]components[\\\\/].*\\$.+\.tsx?$`
-        )
-        return regexp.test(path.resolve(id))
-      },
-      appDir,
+      islandDir,
     }),
     injectImportingIslands({
+      islandDir,
       appDir,
     }),
     mdx({

--- a/test-integration/vitest.config.ts
+++ b/test-integration/vitest.config.ts
@@ -5,6 +5,7 @@ import { injectImportingIslands } from '../src/vite/inject-importing-islands'
 import { islandComponents } from '../src/vite/island-components'
 
 const root = './mocks'
+const appDir = '/mocks'
 
 export default defineConfig({
   resolve: {
@@ -18,12 +19,15 @@ export default defineConfig({
       isIsland: (id) => {
         const resolvedPath = path.resolve(root).replace(/\\/g, '\\\\')
         const regexp = new RegExp(
-          `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].*\\$.+\.tsx?$`
+          `${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]islands[\\\\/].+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].+\.island\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]routes[\\\\/].*\\$.+\.tsx?$|${resolvedPath}[\\\\/]app[^\\\\/]*[\\\\/]components[\\\\/].*\\$.+\.tsx?$`
         )
         return regexp.test(path.resolve(id))
       },
+      appDir,
     }),
-    injectImportingIslands(),
+    injectImportingIslands({
+      appDir,
+    }),
     mdx({
       jsxImportSource: 'hono/jsx',
     }),


### PR DESCRIPTION
With this PR, we can put island components anywhere instead of under `/app/routes` or `/app/islands`. For example, the components placed like the following will be treated as islands.

* `/app/components/$counter.tsx`
* `/app/components/_counter.island.tsx`

In addition, I've added the following changes:

* Made it islands directory only `^/islands` or specify the path if passing the option.
* Corrected importing path of client components in the client.
* Simplify some options.
* Fixed resolving alias path.
* Added some missing tests.

Fixes #159