### PR TITLE
feat: support `.md`

### DIFF
--- a/src/server/utils/file.ts
+++ b/src/server/utils/file.ts
@@ -1,7 +1,7 @@
 export const filePathToPath = (filePath: string) => {
   filePath = filePath
     .replace(/\.tsx?$/g, '')
-    .replace(/\.mdx$/g, '')
+    .replace(/\.mdx?$/g, '')
     .replace(/^\/?index$/, '/') // `/index`
     .replace(/\/index$/, '') // `/about/index`
     .replace(/\[\.{3}.+\]/, '*')

--- a/src/server/with-defaults.ts
+++ b/src/server/with-defaults.ts
@@ -32,8 +32,8 @@ export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
       options?.ROUTES ??
       import.meta.glob(
         [
-          '/app/routes/**/!(_*|*.test|*.spec).(ts|tsx|mdx)',
-          '/app/routes/.well-known/!(_*|*.test|*.spec).(ts|tsx|mdx)',
+          '/app/routes/**/!(_*|*.test|*.spec).(ts|tsx|md|mdx)',
+          '/app/routes/.well-known/!(_*|*.test|*.spec).(ts|tsx|md|mdx)',
         ],
         {
           eager: true,


### PR DESCRIPTION
This PR adds `.md` as a route file extension and also supports omission of the extension.
This should be provided as a config so that other extensions can do this, but [vite does not support it](https://vitejs.dev/guide/features#:~:text=You%20can%20NOT%20use%20variables%20or%20expressions%20in%20them.).

closes: #187 