### PR TITLE
feat: add `client` plugin to `honox/vite`

### DIFF
--- a/src/vite/client.ts
+++ b/src/vite/client.ts
@@ -1,23 +1,32 @@
 import type { Plugin } from 'vite'
 
-type Options = {
+export type ClientOptions = {
   jsxImportSource?: string
   assetsDir?: string
+  input?: string[]
 }
 
-export const defaultOptions: Options = {
+export const defaultOptions: ClientOptions = {
   jsxImportSource: 'hono/jsx/dom',
   assetsDir: 'static',
+  input: [],
 }
 
-function client(options?: Options): Plugin {
+function client(options?: ClientOptions): Plugin {
   return {
     name: 'honox-vite-client',
+    apply: (_config, { command, mode }) => {
+      if (command === 'build' && mode === 'client') {
+        return true
+      }
+      return false
+    },
     config: () => {
+      const input = options?.input ?? defaultOptions.input ?? []
       return {
         build: {
           rollupOptions: {
-            input: ['/app/client.ts'],
+            input: ['/app/client.ts', ...input],
           },
           assetsDir: options?.assetsDir ?? defaultOptions.assetsDir,
           manifest: true,

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -6,12 +6,15 @@ import { injectImportingIslands } from './inject-importing-islands.js'
 import { islandComponents } from './island-components.js'
 import type { IslandComponentsOptions } from './island-components.js'
 import { restartOnAddUnlink } from './restart-on-add-unlink.js'
+import type { ClientOptions } from './client.js'
+import client from './client.js'
 
 type Options = {
   islands?: boolean
   entry?: string
   devServer?: DevServerOptions
   islandComponents?: IslandComponentsOptions
+  client?: ClientOptions
   external?: string[]
 }
 
@@ -44,6 +47,7 @@ function honox(options?: Options): PluginOption[] {
 
   plugins.push(injectImportingIslands())
   plugins.push(restartOnAddUnlink())
+  plugins.push(client(options?.client))
 
   return [
     {


### PR DESCRIPTION
Then you don't have to write:

```ts
export default defineConfig(({ mode }) => {
  if (mode === 'client') {
    return {
      build: {
        rollupOptions: {
          input: ['/app/style.css']
        }
      },
      plugins: [clientBuild()]
    }
  } else {
    return {
      plugins: [
        honox({
          devServer: {
            adapter
          }
        }),
        ssrBuild()
      ]
    }
  }
})
```

Instead of it, you can write it shortly:

```ts
export default defineConfig({
  plugins: [
    honox({
      devServer: {
        adapter
      },
      client: {
        input: ['/app/style.css']
      }
    }),
    pages()
  ]
})
```