### PR TITLE
fix: default routes include well-known URIs with several path segments

### DIFF
--- a/src/server/with-defaults.ts
+++ b/src/server/with-defaults.ts
@@ -33,7 +33,7 @@ export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
       import.meta.glob(
         [
           '/app/routes/**/!(_*|$*|*.test|*.spec).(ts|tsx|md|mdx)',
-          '/app/routes/.well-known/!(_*|$*|*.test|*.spec).(ts|tsx|md|mdx)',
+          '/app/routes/.well-known/**/!(_*|$*|*.test|*.spec).(ts|tsx|md|mdx)',
         ],
         {
           eager: true,


### PR DESCRIPTION
[RFC6920 defines](https://www.rfc-editor.org/rfc/rfc6920.html#section-8.1) some well-known routes like:

http://example.com/.well-known/ni/sha-256/f4OxZX_x_FO5LcGBSKHWXfwtSx-j1ncoSt3SABJtkGk

Note that there are three path segments after the `/.well-known/` path prefix.

In my honox /app directory, I crated `/app/routes/.well-known/ni/[alg]/[val].tsx` but it didn't work. (it does work if I directly nest at `/app/routes/.well-known/[val].tsx`).

Based on cursory local testing of this change. I think this change accomodates for several path segments beyond `/.well-known/` as well as only one.