### PR TITLE
add "prepare" npm script so this works when depended on via git link

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
+    "prepare": "tsup",
     "test": "bun typecheck && bun test:unit && bun test:integration && bun test:e2e",
     "test:unit": "vitest --run ./src",
     "test:integration": "bun test:integration:api && bun test:integration:apps",


### PR DESCRIPTION
I added my fork of this repo to my project as a npm git dependency, but it didn't work until I did this.

https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts
> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.