### PR TITLE
chore: fixed NOT_FOUND regex for mocks server

### DIFF
--- a/mocks/app/server.ts
+++ b/mocks/app/server.ts
@@ -10,7 +10,7 @@ const RENDERER = import.meta.glob('./routes/**/_renderer.tsx', {
   eager: true,
 })
 
-const NOT_FOUND = import.meta.glob('./routes/**/_404.(ts|tsx', {
+const NOT_FOUND = import.meta.glob('./routes/**/_404.(ts|tsx)', {
   eager: true,
 })
 


### PR DESCRIPTION
This pull request fixes NOT_FOUND regex for `mocks/app/server.ts`.