### PR TITLE
fix: Make `<Link />` not async

### DIFF
--- a/src/server/components/link.tsx
+++ b/src/server/components/link.tsx
@@ -4,7 +4,7 @@ import type { Manifest } from 'vite'
 
 type Options = { manifest?: Manifest; prod?: boolean } & JSX.IntrinsicElements['link']
 
-export const Link: FC<Options> = async (options) => {
+export const Link: FC<Options> = (options) => {
   let { href, prod, manifest, ...rest } = options
   if (href) {
     if (prod ?? import.meta.env.PROD) {


### PR DESCRIPTION
## Problem

`<Link />` is an async component in spite of unnecessary and because of this causes following error in Deno:

```
A component suspended while responding to synchronous input. This will cause the UI to be replaced with a loading indicator. To fix, updates that suspend should be wrapped with startTransition.
Error: A component suspended while responding to synchronous input. This will cause the UI to be replaced with a loading indicator. To fix, updates that suspend should be wrapped with startTransition.
    at renderToStringImpl (file:///Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/react-dom@19.0.0/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:7125:15)
    at process.env.NODE_ENV.exports.renderToString (file:///Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/react-dom@19.0.0/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:8566:14)
    at Context.eval (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/@hono+react-renderer@0.2.1/node_modules/@hono/react-renderer/dist/index.js, <anonymous>:26:68)
    at Context.render (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/hono@4.6.16/node_modules/hono/dist/context.js, <anonymous>:98:26)
    at handler (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/app/routes/_error.tsx, <anonymous>:10:12)
    at errorHandler (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/honox@0.1.29/node_modules/honox/dist/server/server.js, <anonymous>:171:20)
    at dispatch (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/hono@4.6.16/node_modules/hono/dist/compose.js, <anonymous>:38:25)
    at async handler (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/hono@4.6.16/node_modules/hono/dist/hono-base.js, <anonymous>:95:39)
    at async dispatch (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/hono@4.6.16/node_modules/hono/dist/compose.js, <anonymous>:32:17)
    at async Object.innerMeta [as handler] (/Users/234531sch/Library/Develops/github.com/4513ECHO/etude-honox-deno/node_modules/.deno/honox@0.1.29/node_modules/honox/dist/server/server.js, <anonymous>:85:11)
```

## Solution

I have removed async declation.