### PR TITLE
feat: support for deno.jsonc in vite plugin

### DIFF
--- a/src/vite/island-components.test.ts
+++ b/src/vite/island-components.test.ts
@@ -235,9 +235,27 @@ describe('options', () => {
 
       test.each([
         {
-          name: 'default with both config files (deno.json preferred)',
+          name: 'default with both config files (prefers deno.json over tsconfig.json)',
           configFiles: {
             'deno.json': { jsxImportSource: 'react' },
+            'tsconfig.json': { jsxImportSource: 'hono/jsx' },
+          },
+          config: {},
+          expect: { hono: false, react: true },
+        },
+        {
+          name: 'default with both config files (prefers deno.json over deno.jsonc)',
+          configFiles: {
+            'deno.json': { jsxImportSource: 'react' },
+            'deno.jsonc': { jsxImportSource: 'hono/jsx' },
+          },
+          config: {},
+          expect: { hono: false, react: true },
+        },
+        {
+          name: 'default with both config files (prefers deno.jsonc over tsconfig.json)',
+          configFiles: {
+            'deno.jsonc': { jsxImportSource: 'react' },
             'tsconfig.json': { jsxImportSource: 'hono/jsx' },
           },
           config: {},
@@ -247,6 +265,14 @@ describe('options', () => {
           name: 'default with only deno.json',
           configFiles: {
             'deno.json': { jsxImportSource: 'react' },
+          },
+          config: {},
+          expect: { hono: false, react: true },
+        },
+        {
+          name: 'default with only deno.jsonc',
+          configFiles: {
+            'deno.jsonc': { jsxImportSource: 'react' },
           },
           config: {},
           expect: { hono: false, react: true },
@@ -263,6 +289,7 @@ describe('options', () => {
           name: 'explicit react config overrides all',
           configFiles: {
             'deno.json': { jsxImportSource: 'hono/jsx' },
+            'deno.jsonc': { jsxImportSource: 'hono/jsx' },
             'tsconfig.json': { jsxImportSource: 'hono/jsx' },
           },
           config: { reactApiImportSource: 'react' },

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -230,7 +230,6 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
           console.warn('Cannot find tsconfig.json or deno.json(c)')
           return
         }
-
         const tsConfig = parseJsonc(tsConfigRaw)
 
         reactApiImportSource = tsConfig?.compilerOptions?.jsxImportSource

--- a/src/vite/island-components.ts
+++ b/src/vite/island-components.ts
@@ -217,19 +217,20 @@ export function islandComponents(options?: IslandComponentsOptions): Plugin {
       root = config.root
 
       if (!reactApiImportSource) {
-        const tsConfigPath = path.resolve(process.cwd(), 'tsconfig.json')
-        const denoJsonPath = path.resolve(process.cwd(), 'deno.json')
-        let tsConfigRaw: string
-        try {
-          tsConfigRaw = await fs.readFile(denoJsonPath, 'utf8')
-        } catch (error1) {
+        const tsConfigFiles = ['deno.json', 'deno.jsonc', 'tsconfig.json']
+        let tsConfigRaw: string | undefined
+        for (const tsConfigFile of tsConfigFiles) {
           try {
+            const tsConfigPath = path.resolve(process.cwd(), tsConfigFile)
             tsConfigRaw = await fs.readFile(tsConfigPath, 'utf8')
-          } catch (error2) {
-            console.warn('Cannot find neither tsconfig.json nor deno.json', error1, error2)
-            return
-          }
+            break
+          } catch {}
         }
+        if (!tsConfigRaw) {
+          console.warn('Cannot find tsconfig.json or deno.json(c)')
+          return
+        }
+
         const tsConfig = parseJsonc(tsConfigRaw)
 
         reactApiImportSource = tsConfig?.compilerOptions?.jsxImportSource


### PR DESCRIPTION
Related: #249 

#249 supported for deno.json, but not deno.jsonc. This PR will support for that.

I removed the errors from `console.warn`, but I will add it if necessary.
There are too many errors to display, so we need some ingenuity.