### PR TITLE
feat: Route grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Below is a typical project structure for a HonoX application.
 │   │   ├── about
 │   │   │   └── [name].tsx // matches `/about/:name`
 │   │   ├── blog
-│   │   │   ├── index.tsx // matches /blog/index
+│   │   │   ├── index.tsx // matches /blog
 │   │   │   └── (content)
 │   │   │       ├── _renderer.tsx // renderer definition for routes inside this directory
 │   │   │       └── [name].tsx    // matches `/blog/:name`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Below is a typical project structure for a HonoX application.
 │   │   ├── _renderer.tsx // renderer definition
 │   │   ├── about
 │   │   │   └── [name].tsx // matches `/about/:name`
+│   │   ├── blog
+│   │   │   ├── index.tsx // matches /blog/index
+│   │   │   └── (content)
+│   │   │       ├── _renderer.tsx // renderer definition for routes inside this directory
+│   │   │       └── [name].tsx    // matches `/blog/:name`
 │   │   └── index.tsx // matches `/`
 │   └── server.ts // server entry file
 ├── package.json

--- a/mocks/app-route-groups/routes/_renderer.tsx
+++ b/mocks/app-route-groups/routes/_renderer.tsx
@@ -1,0 +1,21 @@
+import { jsxRenderer } from 'hono/jsx-renderer'
+import { HasIslands } from '../../../src/server'
+
+export default jsxRenderer(
+  ({ children, title }) => {
+    return (
+      <html>
+        <head>
+          <title>{title}</title>
+        </head>
+        <body>
+          {children}
+          <HasIslands>
+            <script type='module' async src='/app/client.ts'></script>
+          </HasIslands>
+        </body>
+      </html>
+    )
+  },
+  { stream: true }
+)

--- a/mocks/app-route-groups/routes/blog/(content-group)/_middleware.ts
+++ b/mocks/app-route-groups/routes/blog/(content-group)/_middleware.ts
@@ -1,0 +1,9 @@
+import { createMiddleware } from 'hono/factory'
+import { createRoute } from '../../../../../src/factory'
+
+const addHeader = createMiddleware(async (c, next) => {
+  await next()
+  c.res.headers.append('x-message', 'from middleware for (content-group)')
+})
+
+export default createRoute(addHeader)

--- a/mocks/app-route-groups/routes/blog/(content-group)/_renderer.tsx
+++ b/mocks/app-route-groups/routes/blog/(content-group)/_renderer.tsx
@@ -1,0 +1,15 @@
+import { jsxRenderer } from 'hono/jsx-renderer'
+
+export default jsxRenderer(
+  ({ children, Layout }) => {
+    return (
+      <Layout>
+        <div>
+          <h1>Blog</h1>
+          {children}
+        </div>
+      </Layout>
+    )
+  },
+  { stream: true }
+)

--- a/mocks/app-route-groups/routes/blog/(content-group)/hello-world.mdx
+++ b/mocks/app-route-groups/routes/blog/(content-group)/hello-world.mdx
@@ -1,0 +1,1 @@
+Hello World

--- a/mocks/app-route-groups/routes/blog/index.tsx
+++ b/mocks/app-route-groups/routes/blog/index.tsx
@@ -1,0 +1,5 @@
+export default function BLogPosts() {
+  return (
+    <div>Here lies the blog posts</div>
+  )
+}

--- a/mocks/app-route-groups/routes/index.tsx
+++ b/mocks/app-route-groups/routes/index.tsx
@@ -1,0 +1,7 @@
+import { createRoute } from '../../../src/factory'
+
+export default createRoute((c) => {
+  return c.render(<h1>Hello</h1>, {
+    title: 'This is a title',
+  })
+})

--- a/mocks/app-route-groups/server.ts
+++ b/mocks/app-route-groups/server.ts
@@ -1,0 +1,39 @@
+import { showRoutes } from 'hono/dev'
+import { logger } from 'hono/logger'
+import { createApp } from '../../src/server'
+
+const ROUTES = import.meta.glob('./routes/**/[a-z[-][a-z[_-]*.(tsx|ts)', {
+  eager: true,
+})
+
+const RENDERER = import.meta.glob('./routes/**/_renderer.tsx', {
+  eager: true,
+})
+
+const NOT_FOUND = import.meta.glob('./routes/**/_404.(ts|tsx)', {
+  eager: true,
+})
+
+const ERROR = import.meta.glob('./routes/**/_error.(ts|tsx)', {
+  eager: true,
+})
+
+const app = createApp({
+  // @ts-expect-error type is not specified
+  ROUTES,
+  // @ts-expect-error type is not specified
+  RENDERER,
+  // @ts-expect-error type is not specified
+  NOT_FOUND,
+  // @ts-expect-error type is not specified
+  ERROR,
+  root: './routes',
+  init: (app) => {
+    app.use(logger())
+  },
+})
+showRoutes(app, {
+  verbose: true,
+})
+
+export default app

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -150,7 +150,12 @@ export const createApp = <E extends Env>(options: BaseServerOptions<E>): Hono<E>
       })
 
       const middlewareFile = Object.keys(MIDDLEWARE_FILE).find((x) => {
-        const replacedDir = dir.replaceAll('[', '\\[').replace(']', '\\]')
+        const replacedDir = dir
+          .replaceAll('[', '\\[')
+          .replaceAll(']', '\\]')
+          .replaceAll('(', '\\(')
+          .replaceAll(')', '\\)')
+
         return new RegExp(replacedDir + '/_middleware.tsx?').test(x)
       })
 

--- a/src/server/utils/file.test.ts
+++ b/src/server/utils/file.test.ts
@@ -28,6 +28,9 @@ describe('filePathToPath', () => {
     expect(filePathToPath('/about/[...foo].tsx')).toBe('/about/*')
     expect(filePathToPath('/about/[name]/address.tsx')).toBe('/about/:name/address')
     expect(filePathToPath('/about/[arg1]/[arg2]')).toBe('/about/:arg1/:arg2')
+
+    expect(filePathToPath('/articles/(grouped1)/[slug]')).toBe('/articles/:slug')
+    expect(filePathToPath('/articles/(grouped1)/[slug]/(grouped1)/edit')).toBe('/articles/:slug/edit')
   })
 })
 
@@ -39,6 +42,7 @@ describe('groupByDirectory', () => {
     '/app/routes/blog/about.tsx': 'file4',
     '/app/routes/blog/posts/index.tsx': 'file5',
     '/app/routes/blog/posts/comments.tsx': 'file6',
+    '/app/routes/articles/(content)/[slug].tsx': 'file7',
   }
 
   it('Should group by directories', () => {
@@ -55,6 +59,9 @@ describe('groupByDirectory', () => {
         'index.tsx': 'file5',
         'comments.tsx': 'file6',
       },
+      '/app/routes/articles/(content)': {
+        '[slug].tsx': 'file7'
+      }
     })
   })
 })

--- a/src/server/utils/file.test.ts
+++ b/src/server/utils/file.test.ts
@@ -30,7 +30,9 @@ describe('filePathToPath', () => {
     expect(filePathToPath('/about/[arg1]/[arg2]')).toBe('/about/:arg1/:arg2')
 
     expect(filePathToPath('/articles/(grouped1)/[slug]')).toBe('/articles/:slug')
-    expect(filePathToPath('/articles/(grouped1)/[slug]/(grouped1)/edit')).toBe('/articles/:slug/edit')
+    expect(filePathToPath('/articles/(grouped1)/[slug]/(grouped1)/edit')).toBe(
+      '/articles/:slug/edit'
+    )
   })
 })
 
@@ -60,8 +62,8 @@ describe('groupByDirectory', () => {
         'comments.tsx': 'file6',
       },
       '/app/routes/articles/(content)': {
-        '[slug].tsx': 'file7'
-      }
+        '[slug].tsx': 'file7',
+      },
     })
   })
 })

--- a/src/server/utils/file.ts
+++ b/src/server/utils/file.ts
@@ -5,6 +5,7 @@ export const filePathToPath = (filePath: string) => {
     .replace(/^\/?index$/, '/') // `/index`
     .replace(/\/index$/, '') // `/about/index`
     .replace(/\[\.{3}.+\]/, '*')
+    .replace(/\((.+?)\)/g, '')
     .replace(/\[(.+?)\]/g, ':$1')
   return /^\//.test(filePath) ? filePath : '/' + filePath
 }

--- a/src/server/utils/file.ts
+++ b/src/server/utils/file.ts
@@ -7,6 +7,7 @@ export const filePathToPath = (filePath: string) => {
     .replace(/\[\.{3}.+\]/, '*')
     .replace(/\((.+?)\)/g, '')
     .replace(/\[(.+?)\]/g, ':$1')
+    .replace(/\/\//g, '/')
   return /^\//.test(filePath) ? filePath : '/' + filePath
 }
 

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -925,9 +925,12 @@ describe('Function Component Response', () => {
 })
 
 describe('Route Groups', () => {
-  const ROUTES = import.meta.glob('../mocks/app-route-groups/routes/**/[a-z[-][a-z[_-]*.(tsx|ts|mdx)', {
-    eager: true,
-  })
+  const ROUTES = import.meta.glob(
+    '../mocks/app-route-groups/routes/**/[a-z[-][a-z[_-]*.(tsx|ts|mdx)',
+    {
+      eager: true,
+    }
+  )
   const RENDERER = import.meta.glob('../mocks/app-route-groups/routes/**/_renderer.tsx', {
     eager: true,
   })
@@ -982,14 +985,13 @@ describe('Route Groups', () => {
     )
   })
 
-
-
   it('Should render /blog without (content) route group layout', async () => {
     const res = await app.request('/blog')
     expect(res.status).toBe(200)
     expect(res.headers.get('x-message')).not.toBe('from middleware for (content-group)')
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><div>Here lies the blog posts</div></body></html>')
+      '<!DOCTYPE html><html><head><title></title></head><body><div>Here lies the blog posts</div></body></html>'
+    )
   })
 
   it('Should render /blog/hello-world MDX with (content) route group layout', async () => {
@@ -997,6 +999,7 @@ describe('Route Groups', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('x-message')).toBe('from middleware for (content-group)')
     expect(await res.text()).toBe(
-      '<!DOCTYPE html><html><head><title></title></head><body><div><h1>Blog</h1><p>Hello World</p></div></body></html>')
+      '<!DOCTYPE html><html><head><title></title></head><body><div><h1>Blog</h1><p>Hello World</p></div></body></html>'
+    )
   })
 })

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -934,7 +934,7 @@ describe('Route Groups', () => {
   const NOT_FOUND = import.meta.glob('../mocks/app-route-groups/routes/**/_404.(ts|tsx)', {
     eager: true,
   })
-  const MIDDLEWARE = import.meta.glob('../mocks/app/routes/**/_middleware.(tsx|ts)', {
+  const MIDDLEWARE = import.meta.glob('../mocks/app-route-groups/routes/**/_middleware.(tsx|ts)', {
     eager: true,
   })
 
@@ -968,7 +968,7 @@ describe('Route Groups', () => {
         method: 'GET',
       },
     ]
-    expect(app.routes).toHaveLength(12)
+    expect(app.routes).toHaveLength(13)
     expect(app.routes).toEqual(
       expect.arrayContaining(
         routes.map(({ path, method }) => {

--- a/test-integration/apps.test.ts
+++ b/test-integration/apps.test.ts
@@ -934,12 +934,16 @@ describe('Route Groups', () => {
   const NOT_FOUND = import.meta.glob('../mocks/app-route-groups/routes/**/_404.(ts|tsx)', {
     eager: true,
   })
+  const MIDDLEWARE = import.meta.glob('../mocks/app/routes/**/_middleware.(tsx|ts)', {
+    eager: true,
+  })
 
   const app = createApp({
     root: '../mocks/app-route-groups/routes',
     ROUTES: ROUTES as any,
     RENDERER: RENDERER as any,
     NOT_FOUND: NOT_FOUND as any,
+    MIDDLEWARE: MIDDLEWARE as any,
     init: (app) => {
       app.use('*', poweredBy())
     },
@@ -983,12 +987,16 @@ describe('Route Groups', () => {
   it('Should render /blog without (content) route group layout', async () => {
     const res = await app.request('/blog')
     expect(res.status).toBe(200)
+    expect(res.headers.get('x-message')).not.toBe('from middleware for (content-group)')
+    expect(await res.text()).toBe(
       '<!DOCTYPE html><html><head><title></title></head><body><div>Here lies the blog posts</div></body></html>')
   })
 
   it('Should render /blog/hello-world MDX with (content) route group layout', async () => {
     const res = await app.request('/blog/hello-world')
     expect(res.status).toBe(200)
+    expect(res.headers.get('x-message')).toBe('from middleware for (content-group)')
+    expect(await res.text()).toBe(
       '<!DOCTYPE html><html><head><title></title></head><body><div><h1>Blog</h1><p>Hello World</p></div></body></html>')
   })
 })


### PR DESCRIPTION
Enable/allow routes to have grouping without adjusting their path. eg.:

Given structure
```
app/
  routes/
    index.ts
    blog/
      index.ts
      (content)/ # not added to the actual path
        _renderer.tsx
        _middleware.ts
        lorem-ipsum.mdx
        hello-world.mdx
```

| Path              | Route File                      |
|-------------------|---------------------------------|
| /                 | index.ts                        |
| /blog             | /blog/index.ts                  |
| /blog/lorem-ipsum | /blog/(content)/lorem-ipsum.mdx |
| /blog/hello-world | /blog/(content)/hello-world.mdx |

Routes in `(content)` also has `_renderer.tsx` and `_middleware.ts` applied to them, but not to route in parent directory (`/blog`)

This solves https://github.com/honojs/honox/issues/237, just in different solution - `(name)` is also used by other file-based routers, and here `_` prefix seems to be better for reserved keyword files.
