### PR TITLE
docs(readme): add Config of React with `<Script />`

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,59 @@ Adjust `tsconfig.json` jsx factory function option.
 
 ```
 
+#### Use React with `<Script />`
+
+If you export a manifest file in `dist/.vite/manifest.json`, you can easily write some codes using `<Script />`.
+
+```tsx
+// app/routes/_renderer.tsx
+import { reactRenderer } from '@hono/react-renderer'
+
+export default reactRenderer(({ children, title }) => {
+  return (
+    <html lang='en'>
+      <head>
+        <meta charSet='UTF-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        <Script src="/app/client.ts" async />
+        {title ? <title>{title}</title> : ''}
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+})
+```
+
+Configure react in `vite.config.ts`.
+
+```ts
+// vite.config.ts
+import build from '@hono/vite-build/cloudflare-pages'
+import honox from 'honox/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig(({ mode }) => {
+  if (mode === 'client') {
+    return {
+      build: {
+        rollupOptions: {
+          input: ['./app/client.ts'],
+        },
+        manifest: true,
+        emptyOutDir: false,
+      },
+    }
+  } else {
+    return {
+      ssr: {
+        external: ['react', 'react-dom'],
+      },
+      plugins: [honox(), build()],
+    }
+  }
+})
+```
+
 ## Guides
 
 ### Nested Layouts

--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ If you export a manifest file in `dist/.vite/manifest.json`, you can easily writ
 ```tsx
 // app/routes/_renderer.tsx
 import { reactRenderer } from '@hono/react-renderer'
+import { Script } from 'honox/server'
 
 export default reactRenderer(({ children, title }) => {
   return (


### PR DESCRIPTION
Hello. Thank you for your nice project.

This PR adds a new subsection into the section of React in the README demonstrating how to use the recently introduced `<Script />` tag for manifest-based script injection.

I have considered wholely replacing the section since it's more simple way to use the `<Script />` tag (according to [the article](https://zenn.dev/yusukebe/articles/4d6297f3be121a#scriptとlinkコンポーネント), you know) in recent HonoX, but for now I'll just add the subsection.
