### PR TITLE
refactor: default dev server options should include the honox default.

### DIFF
--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -33,7 +33,7 @@ const devServerDefaultOptions = {
   ],
   handleHotUpdate: () => {
     return undefined
-  }
+  },
 }
 
 function honox(options?: Options): PluginOption[] {

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -33,9 +33,13 @@ function honox(options?: Options): PluginOption[] {
       entry,
       exclude: [
         ...devServerDefaultOptions.exclude,
+        ...(options?.devServer?.exclude || []),
         /^\/app\/.+\.tsx?/,
         /^\/favicon.ico/,
         /^\/static\/.+/,
+      ],
+      ignoreWatching: [
+        ...(options?.devServer?.ignoreWatching || []),
       ],
       handleHotUpdate: () => {
         return undefined

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -31,6 +31,9 @@ const devServerDefaultOptions = {
     /^\/favicon.ico/,
     /^\/static\/.+/,
   ],
+  handleHotUpdate: () => {
+    return undefined
+  }
 }
 
 function honox(options?: Options): PluginOption[] {
@@ -42,9 +45,6 @@ function honox(options?: Options): PluginOption[] {
     devServer({
       ...devServerDefaultOptions,
       entry,
-      handleHotUpdate: () => {
-        return undefined
-      },
       ...options?.devServer,
     })
   )

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,4 +1,4 @@
-import devServer, { defaultOptions as devServerDefaultOptions } from '@hono/vite-dev-server'
+import devServer, { defaultOptions as viteDevServerDefaultOptions } from '@hono/vite-dev-server'
 import type { DevServerOptions } from '@hono/vite-dev-server'
 import type { PluginOption } from 'vite'
 import path from 'path'
@@ -23,6 +23,16 @@ export const defaultOptions: Options = {
   entry: path.join(process.cwd(), './app/server.ts'),
 }
 
+const devServerDefaultOptions = {
+  ...viteDevServerDefaultOptions,
+  exclude: [
+    ...viteDevServerDefaultOptions.exclude,
+    /^\/app\/.+\.tsx?/,
+    /^\/favicon.ico/,
+    /^\/static\/.+/,
+  ],
+}
+
 function honox(options?: Options): PluginOption[] {
   const plugins: PluginOption[] = []
 
@@ -30,17 +40,8 @@ function honox(options?: Options): PluginOption[] {
 
   plugins.push(
     devServer({
+      ...devServerDefaultOptions,
       entry,
-      exclude: [
-        ...devServerDefaultOptions.exclude,
-        ...(options?.devServer?.exclude || []),
-        /^\/app\/.+\.tsx?/,
-        /^\/favicon.ico/,
-        /^\/static\/.+/,
-      ],
-      ignoreWatching: [
-        ...(options?.devServer?.ignoreWatching || []),
-      ],
       handleHotUpdate: () => {
         return undefined
       },


### PR DESCRIPTION
devServerDefaultOptions in this file doesn't have the exclusions below:
- /^\/app\/.+\.tsx?/,
- /^\/favicon.ico/,
- /^\/static\/.+/,

The behavior is a little bit confusing.