### PR TITLE
docs: update README instructions from Cloudflare Pages to Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,20 +839,47 @@ export default function Top() {
 
 ### Cloudflare Bindings
 
-If you want to use Cloudflare's Bindings in your development environment, create `wrangler.toml` and configure it properly.
+If you want to use Cloudflare's Bindings in your development environment, create `wrangler.jsonc` and configure it properly.
 
-```toml
-name = "my-project-name"
-compatibility_date = "2024-04-01"
-compatibility_flags = [ "nodejs_compat" ]
-pages_build_output_dir = "./dist"
-
-# [vars]
-# MY_VARIABLE = "production_value"
-
-# [[kv_namespaces]]
-# binding = "MY_KV_NAMESPACE"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```jsonc
+// wrangler.jsonc
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "my-project-name",
+  "main": "./dist/index.js",
+  "compatibility_date": "2024-04-01",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "assets": {
+    "directory": "./dist"
+  }
+  // "vars": {
+  //   "MY_VAR": "my-variable"
+  // },
+  // "kv_namespaces": [
+  //   {
+  //     "binding": "MY_KV_NAMESPACE",
+  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  //   }
+  // ],
+  // "r2_buckets": [
+  //   {
+  //     "binding": "MY_BUCKET",
+  //     "bucket_name": "my-bucket"
+  //   }
+  // ],
+  // "d1_databases": [
+  //   {
+  //     "binding": "MY_DB",
+  //     "database_name": "my-database",
+  //     "database_id": ""
+  //   }
+  // ],
+  // "ai": {
+  //   "binding": "AI"
+  // }
+}
 ```
 
 In `vite.config.ts`, use the Cloudflare Adapter in `@hono/vite-dev-server`.

--- a/README.md
+++ b/README.md
@@ -853,31 +853,6 @@ If you want to use Cloudflare's Bindings in your development environment, create
   ],
   "assets": {
     "directory": "./dist"
-  },
-  "vars": {
-    "MY_VAR": "my-variable"
-  },
-  "kv_namespaces": [
-    {
-      "binding": "MY_KV_NAMESPACE",
-      "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    }
-  ],
-  "r2_buckets": [
-    {
-      "binding": "MY_BUCKET",
-      "bucket_name": "my-bucket"
-    }
-  ],
-  "d1_databases": [
-    {
-      "binding": "MY_DB",
-      "database_name": "my-database",
-      "database_id": ""
-    }
-  ],
-  "ai": {
-    "binding": "AI"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ If you want to use Cloudflare's Bindings in your development environment, create
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "my-project-name",
   "main": "./dist/index.js",
-  "compatibility_date": "2024-04-01",
+  "compatibility_date": "2025-08-03",
   "compatibility_flags": [
     "nodejs_compat"
   ],
@@ -971,7 +971,7 @@ Add the `wrangler.jsonc`:
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "my-project-name",
   "main": "./dist/index.js",
-  "compatibility_date": "2024-04-01",
+  "compatibility_date": "2025-08-03",
   "compatibility_flags": [
     "nodejs_compat"
   ],

--- a/README.md
+++ b/README.md
@@ -853,32 +853,32 @@ If you want to use Cloudflare's Bindings in your development environment, create
   ],
   "assets": {
     "directory": "./dist"
+  },
+  "vars": {
+    "MY_VAR": "my-variable"
+  },
+  "kv_namespaces": [
+    {
+      "binding": "MY_KV_NAMESPACE",
+      "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "MY_BUCKET",
+      "bucket_name": "my-bucket"
+    }
+  ],
+  "d1_databases": [
+    {
+      "binding": "MY_DB",
+      "database_name": "my-database",
+      "database_id": ""
+    }
+  ],
+  "ai": {
+    "binding": "AI"
   }
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Configure react in `vite.config.ts`.
 
 ```ts
 // vite.config.ts
-import build from '@hono/vite-build/cloudflare-pages'
+import build from '@hono/vite-build/cloudflare-workers'
 import honox from 'honox/vite'
 import { defineConfig } from 'vite'
 
@@ -571,7 +571,7 @@ Configure react in `vite.config.ts`.
 
 ```ts
 // vite.config.ts
-import build from '@hono/vite-build/cloudflare-pages'
+import build from '@hono/vite-build/cloudflare-workers'
 import honox from 'honox/vite'
 import { defineConfig } from 'vite'
 
@@ -767,7 +767,7 @@ Finally, add `vite.config.ts` configuration to output assets for the production.
 ```ts
 import honox from 'honox/vite'
 import { defineConfig } from 'vite'
-import build from '@hono/vite-build/cloudflare-pages'
+import build from '@hono/vite-build/cloudflare-workers'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({


### PR DESCRIPTION
Cloudflare recommends migrating from Pages to Workers[^1][^2].  
Following this guidance, we have updated the example code in the README to use Cloudflare Workers instead of Cloudflare Pages.

[^1]: https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/
[^2]: https://x.com/yusukebe/status/1917869496267915641