### PR TITLE
fix: `_middleware.ts` supports Optional Parameter and Regexp routing

### DIFF
--- a/mocks/app-with-mount-patterns/routes/_middleware.ts
+++ b/mocks/app-with-mount-patterns/routes/_middleware.ts
@@ -1,0 +1,9 @@
+import { createMiddleware } from 'hono/factory'
+import { createRoute } from '../../../src/factory'
+
+const addHeader = createMiddleware(async (c, next) => {
+  await next()
+  c.res.headers.set('x-message', 'from middleware')
+})
+
+export default createRoute(addHeader)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -181,7 +181,7 @@ export const createApp = <E extends Env>(options: BaseServerOptions<E>): Hono<E>
 
           // Apply extra middleware for parent routing patterns like /:lang{en} or /:lang?
           const rootPath = dir.replace(rootRegExp, '')
-          const isRootLevel = !rootPath.includes('/') || rootPath === ''
+          const isRootLevel = !rootPath.includes('/')
           const isSimpleStructure = !Object.keys(content).some((f) => f.includes('/'))
 
           if (Object.keys(content).length > 0 && isRootLevel && isSimpleStructure) {
@@ -231,7 +231,8 @@ export const createApp = <E extends Env>(options: BaseServerOptions<E>): Hono<E>
         const shouldApply = middlewareDir === dir || dir.startsWith(middlewareDir + '/')
 
         if (middleware.default && shouldApply) {
-          subApp.use(...middleware.default)
+          // Use a dynamic route pattern that matches all paths including root
+          subApp.use('/:*{.+}?', ...middleware.default)
 
           // Track that this middleware has been applied to this directory
           if (!appliedMiddlewaresByDirectory.has(dir)) {


### PR DESCRIPTION
Fixes #331