### PR TITLE
fix: prevent EBUSY by avoiding absolute paths in watcher

### DIFF
--- a/src/vite/restart-on-add-unlink.ts
+++ b/src/vite/restart-on-add-unlink.ts
@@ -4,7 +4,7 @@ export function restartOnAddUnlink(): Plugin {
   return {
     name: 'restart-on-add-unlink',
     configureServer(server) {
-      server.watcher.add('/app/**')
+      server.watcher.add('./app/**')
       server.watcher.on('add', async () => {
         await server.restart()
       })


### PR DESCRIPTION
close https://github.com/honojs/honox/issues/309

This pull request changes the `app` directory path added to the chokidar watcher to a relative path. This proposal follows the suggestion made in https://github.com/vitejs/vite/issues/19117#issuecomment-2574415143.