### PR TITLE
feat(server): avoid extglobs for rolldown-vite

### DIFF
--- a/src/server/with-defaults.ts
+++ b/src/server/with-defaults.ts
@@ -8,16 +8,16 @@ export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
     app: options?.app,
     init: options?.init,
     trailingSlash: options?.trailingSlash,
-    // Avoid brace expansion and extglobs for rolldown-vite compatibility
+    // Avoid extglobs for rolldown-vite compatibility
     // ref: https://github.com/vitejs/rolldown-vite/issues/365
     NOT_FOUND:
       options?.NOT_FOUND ??
-      import.meta.glob(['/app/routes/**/_404.ts', '/app/routes/**/_404.tsx'], {
+      import.meta.glob('/app/routes/**/_404.{ts,tsx}', {
         eager: true,
       }),
     ERROR:
       options?.ERROR ??
-      import.meta.glob(['/app/routes/**/_error.ts', '/app/routes/**/_error.tsx'], {
+      import.meta.glob('/app/routes/**/_error.{ts,tsx}', {
         eager: true,
       }),
     RENDERER:
@@ -27,37 +27,20 @@ export const createApp = <E extends Env>(options?: ServerOptions<E>) => {
       }),
     MIDDLEWARE:
       options?.MIDDLEWARE ??
-      import.meta.glob(['/app/routes/**/_middleware.ts', '/app/routes/**/_middleware.tsx'], {
+      import.meta.glob('/app/routes/**/_middleware.{ts,tsx}', {
         eager: true,
       }),
     ROUTES:
       options?.ROUTES ??
       import.meta.glob(
         [
-          '/app/routes/**/*.ts',
-          '/app/routes/**/*.tsx',
-          '/app/routes/**/*.md',
-          '/app/routes/**/*.mdx',
-          '/app/routes/.well-known/**/*.ts',
-          '/app/routes/.well-known/**/*.tsx',
-          '/app/routes/.well-known/**/*.md',
-          '/app/routes/.well-known/**/*.mdx',
-          '!/app/routes/**/_*.ts',
-          '!/app/routes/**/_*.tsx',
-          '!/app/routes/**/_*.md',
-          '!/app/routes/**/_*.mdx',
-          '!/app/routes/**/-*.ts',
-          '!/app/routes/**/-*.tsx',
-          '!/app/routes/**/-*.md',
-          '!/app/routes/**/-*.mdx',
-          '!/app/routes/**/$*.ts',
-          '!/app/routes/**/$*.tsx',
-          '!/app/routes/**/$*.md',
-          '!/app/routes/**/$*.mdx',
-          '!/app/routes/**/*.test.ts',
-          '!/app/routes/**/*.test.tsx',
-          '!/app/routes/**/*.spec.ts',
-          '!/app/routes/**/*.spec.tsx',
+          '/app/routes/**/*.{ts,tsx,md,mdx}',
+          '/app/routes/.well-known/**/*.{ts,tsx,md,mdx}',
+          '!/app/routes/**/_*.{ts,tsx,md,mdx}',
+          '!/app/routes/**/-*.{ts,tsx,md,mdx}',
+          '!/app/routes/**/$*.{ts,tsx,md,mdx}',
+          '!/app/routes/**/*.test.{ts,tsx}',
+          '!/app/routes/**/*.spec.{ts,tsx}',
           '!/app/routes/**/-*/**/*',
         ],
         {


### PR DESCRIPTION
Fixes vitejs/rolldown-vite#349

Currently, rolldown-vite does not support brace expansion and exglobs. Ref: https://github.com/vitejs/vite/issues/21947

This PR will avoid it. It's verbose, but this is a simple way.