### PR TITLE
feat(client): avoid character classes in glob patterns for rolldown-vite

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -12,6 +12,7 @@ import type {
   HydrateComponent,
   TriggerHydration,
 } from '../types.js'
+import { filterByPattern } from './utils/filter.js'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FileCallback = () => Promise<Record<string, Promise<any>>>
@@ -35,11 +36,20 @@ export type ClientOptions = {
 }
 
 export const createClient = async (options?: ClientOptions) => {
-  const FILES = options?.ISLAND_FILES ?? {
-    ...import.meta.glob('/app/islands/**/[a-zA-Z0-9-]+.tsx'),
-    ...import.meta.glob('/app/**/_[a-zA-Z0-9-]+.island.tsx'),
-    ...import.meta.glob('/app/**/$[a-zA-Z0-9-]+.tsx'),
-  }
+  const FILES =
+    options?.ISLAND_FILES ??
+    filterByPattern(
+      {
+        ...import.meta.glob('/app/islands/**/*.tsx'),
+        ...import.meta.glob('/app/**/*.island.tsx'),
+        ...import.meta.glob('/app/**/$*.tsx'),
+      },
+      [
+        /\/[a-zA-Z0-9-]+\.tsx$/, // /app/islands/**/*.tsx
+        /\/_[a-zA-Z0-9-]+\.island\.tsx$/, // /app/**/_*.island.tsx
+        /\/\$[a-zA-Z0-9-]+\.tsx$/, // /app/**/$*.tsx
+      ]
+    )
 
   const hydrateComponent: HydrateComponent = async (document) => {
     const filePromises = Object.keys(FILES).map(async (filePath) => {

--- a/src/client/utils/filter.test.ts
+++ b/src/client/utils/filter.test.ts
@@ -1,0 +1,23 @@
+import { filterByPattern } from './filter'
+
+describe('filterByPattern', () => {
+  it('Should filter files by regex patterns', () => {
+    const files = {
+      '/app/islands/Counter.tsx': 'counter',
+      '/app/islands/_hidden.tsx': 'hidden',
+      '/app/components/_Badge.island.tsx': 'badge',
+      '/app/routes/$id.tsx': 'id',
+    }
+    const patterns = [
+      /\/[a-zA-Z0-9-]+\.tsx$/,
+      /\/_[a-zA-Z0-9-]+\.island\.tsx$/,
+      /\/\$[a-zA-Z0-9-]+\.tsx$/,
+    ]
+
+    expect(filterByPattern(files, patterns)).toEqual({
+      '/app/islands/Counter.tsx': 'counter',
+      '/app/components/_Badge.island.tsx': 'badge',
+      '/app/routes/$id.tsx': 'id',
+    })
+  })
+})

--- a/src/client/utils/filter.ts
+++ b/src/client/utils/filter.ts
@@ -1,0 +1,10 @@
+// Avoid character classes in glob patterns for rolldown-vite compatibility
+// ref: https://github.com/rolldown/rolldown/issues/4973
+export const filterByPattern = <T>(
+  files: Record<string, T>,
+  patterns: RegExp[]
+): Record<string, T> => {
+  return Object.fromEntries(
+    Object.entries(files).filter(([path]) => patterns.some((pattern) => pattern.test(path)))
+  )
+}


### PR DESCRIPTION
Character classes (e.g., `[a-zA-Z0-9-]`) in glob patterns are not supported in rolldown-vite, which breaks the client.

This change filters files with regex instead.