### PR TITLE
fix(server): convert catch-all route params to named params with pattern

### DIFF
--- a/src/server/utils/file.test.ts
+++ b/src/server/utils/file.test.ts
@@ -25,7 +25,7 @@ describe('filePathToPath', () => {
     expect(filePathToPath('/about/me/address.tsx')).toBe('/about/me/address')
 
     expect(filePathToPath('/about/[name].tsx')).toBe('/about/:name')
-    expect(filePathToPath('/about/[...foo].tsx')).toBe('/about/*')
+    expect(filePathToPath('/about/[...foo].tsx')).toBe('/about/:foo{.+}')
     expect(filePathToPath('/about/[name]/address.tsx')).toBe('/about/:name/address')
     expect(filePathToPath('/about/[arg1]/[arg2]')).toBe('/about/:arg1/:arg2')
 

--- a/src/server/utils/file.ts
+++ b/src/server/utils/file.ts
@@ -4,7 +4,7 @@ export const filePathToPath = (filePath: string) => {
     .replace(/\.mdx?$/g, '')
     .replace(/^\/?index$/, '/') // `/index`
     .replace(/\/index$/, '') // `/about/index`
-    .replace(/\[\.{3}.+\]/, '*')
+    .replace(/\[\.{3}(.+?)\]/, ':$1{.+}')
     .replace(/\((.+?)\)/g, '')
     .replace(/\[(.+?)\]/g, ':$1')
     .replace(/\/\/+/g, '/')


### PR DESCRIPTION
close #354

Hi, team!

Change the conversion of catch-all route segments (e.g., `[...slug]`) from `*` to `:slug{.+}` in `filePathToPath`.

This preserves the parameter name, allowing the route handler to access the matched value via `c.req.param("slug")` instead of a wildcard, which is more natural and consistent with other dynamic route parameters.