### PR TITLE
perf: add depTreeCache to walkDependencyTree 

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,30 @@ In this example, `routes/posts.tsx` is routed to `/posts`, but other items start
 
 This feature is useful for colocation.
 
+### Excluding Directories from Island Detection
+
+HonoX walks the dependency tree of each route file to detect island component imports. By default this includes `node_modules`, which allows island components shipped in npm packages to be detected automatically.
+
+If you don't use island components from npm packages and want to speed up the dependency walk, you can exclude specific directories with the `injectImportingIslands.exclude` option:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import honox from 'honox/vite'
+
+export default defineConfig({
+  plugins: [
+    honox({
+      injectImportingIslands: {
+        exclude: ['node_modules'],
+      },
+    }),
+  ],
+})
+```
+
+Any dependency path containing one of the strings in `exclude` will be skipped during the tree walk.
+
 ### Using Tailwind CSS
 
 Given that HonoX is Vite-centric, if you wish to utilize [Tailwind CSS](https://tailwindcss.com/), basically adhere to [the official instructions](https://tailwindcss.com/docs/installation/using-vite).

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { ClientOptions } from './client.js'
 import client from './client.js'
 import { injectImportingIslands } from './inject-importing-islands.js'
+import type { InjectImportingIslandsOptions } from './inject-importing-islands.js'
 import { islandComponents } from './island-components.js'
 import type { IslandComponentsOptions } from './island-components.js'
 import { restartOnAddUnlink } from './restart-on-add-unlink.js'
@@ -14,6 +15,7 @@ type Options = {
   entry?: string
   devServer?: DevServerOptions
   islandComponents?: IslandComponentsOptions
+  injectImportingIslands?: InjectImportingIslandsOptions
   client?: ClientOptions
   external?: string[]
 }
@@ -53,7 +55,7 @@ function honox(options?: Options): PluginOption[] {
     plugins.push(islandComponents(options?.islandComponents))
   }
 
-  plugins.push(injectImportingIslands())
+  plugins.push(injectImportingIslands(options?.injectImportingIslands))
   plugins.push(restartOnAddUnlink())
   plugins.push(client(options?.client))
 

--- a/src/vite/inject-importing-islands.test.ts
+++ b/src/vite/inject-importing-islands.test.ts
@@ -207,4 +207,56 @@ describe('injectImportingIslands', () => {
     expect(result).not.toBeUndefined()
     expect(result.code).toContain(IMPORTING_ISLANDS_ID)
   })
+  it('should clear dependency caches between builds', async () => {
+    const componentPath = await createFile(
+      'app/components/toggle.tsx',
+      `
+      export default function Toggle() {
+        return <div>plain</div>
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/$counter.tsx',
+      `
+      export default function Counter() {
+        return <div>counter</div>
+      }
+    `
+    )
+
+    const routePath = await createFile(
+      'app/routes/cache.tsx',
+      `
+      import Toggle from "../components/toggle.tsx"
+      export default function Page() {
+        return <Toggle />
+      }
+    `
+    )
+
+    const routeSource = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPlugin()
+
+    const firstResult = await callTransform(plugin, routePath, routeSource)
+    expect(firstResult).toBeUndefined()
+
+    await fs.writeFile(
+      componentPath,
+      `
+      import Counter from "./$counter.tsx"
+      export default function Toggle() {
+        return <Counter />
+      }
+    `
+    )
+
+    const buildStart = plugin.buildStart as Function
+    await buildStart()
+
+    const secondResult = await callTransform(plugin, routePath, routeSource)
+    expect(secondResult).not.toBeUndefined()
+    expect(secondResult.code).toContain(IMPORTING_ISLANDS_ID)
+  })
 })

--- a/src/vite/inject-importing-islands.test.ts
+++ b/src/vite/inject-importing-islands.test.ts
@@ -259,4 +259,76 @@ describe('injectImportingIslands', () => {
     expect(secondResult).not.toBeUndefined()
     expect(secondResult.code).toContain(IMPORTING_ISLANDS_ID)
   })
+  it('should cache resolutions per importer', async () => {
+    await createFile(
+      'app/components/a/shared.tsx',
+      `
+      export default function Shared() {
+        return <div>plain</div>
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/a/wrapper.tsx',
+      `
+      import Shared from "./shared"
+      export default function WrapperA() {
+        return <Shared />
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/b/$counter.tsx',
+      `
+      export default function Counter() {
+        return <div>counter</div>
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/b/shared.tsx',
+      `
+      import Counter from "./$counter"
+      export default function Shared() {
+        return <Counter />
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/b/wrapper.tsx',
+      `
+      import Shared from "./shared"
+      export default function WrapperB() {
+        return <Shared />
+      }
+    `
+    )
+
+    const routePath = await createFile(
+      'app/routes/importer-cache.tsx',
+      `
+      import WrapperA from "../components/a/wrapper.tsx"
+      import WrapperB from "../components/b/wrapper.tsx"
+      export default function Page() {
+        return (
+          <>
+            <WrapperA />
+            <WrapperB />
+          </>
+        )
+      }
+    `
+    )
+
+    const routeSource = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPlugin()
+    const result = await callTransform(plugin, routePath, routeSource)
+
+    expect(result).not.toBeUndefined()
+    expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+  })
 })

--- a/src/vite/inject-importing-islands.test.ts
+++ b/src/vite/inject-importing-islands.test.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import path from 'path'
 import { IMPORTING_ISLANDS_ID } from '../constants'
 import { injectImportingIslands } from './inject-importing-islands'
+import honox from './index'
 
 describe('injectImportingIslands', () => {
   let tmpDir: string
@@ -14,15 +15,59 @@ describe('injectImportingIslands', () => {
     return fullPath
   }
 
-  const setupPlugin = async () => {
-    const plugin = await injectImportingIslands({
-      appDir: '/app',
-    })
+  const resolveContext = {
+    resolve: async (importee: string, importer?: string) => {
+      // Simulate Vite's resolve: resolve relative paths based on importer
+      if (importee.startsWith('.')) {
+        const base = importer ? path.dirname(importer) : tmpDir
+        const resolved = path.resolve(base, importee)
+        // Try with .tsx extension if not already present
+        const candidates = [resolved, resolved + '.tsx', resolved + '.ts']
+        for (const candidate of candidates) {
+          try {
+            await fs.access(candidate)
+            return { id: candidate }
+          } catch {
+            // continue
+          }
+        }
+      }
+      return null
+    },
+  }
 
+  const configurePlugin = async (plugin: Awaited<ReturnType<typeof injectImportingIslands>>) => {
     // Simulate configResolved
     const configResolved = plugin.configResolved as Function
     await configResolved({ root: tmpDir })
+  }
 
+  const setupPlugin = async (options?: Parameters<typeof injectImportingIslands>[0]) => {
+    const plugin = await injectImportingIslands({
+      appDir: '/app',
+      ...options,
+    })
+
+    await configurePlugin(plugin)
+
+    return plugin
+  }
+
+  const setupPluginFromHonox = async (options?: Parameters<typeof honox>[0]) => {
+    const plugins = await Promise.all(honox(options).map((plugin) => plugin))
+    const plugin = plugins.find(
+      (candidate): candidate is Awaited<ReturnType<typeof injectImportingIslands>> =>
+        typeof candidate === 'object' &&
+        candidate !== null &&
+        'name' in candidate &&
+        candidate.name === 'inject-importing-islands'
+    )
+
+    if (!plugin) {
+      throw new Error('inject-importing-islands plugin not found')
+    }
+
+    await configurePlugin(plugin)
     return plugin
   }
 
@@ -32,27 +77,7 @@ describe('injectImportingIslands', () => {
     sourceCode: string
   ) => {
     const transform = plugin.transform as Function
-    const context = {
-      resolve: async (importee: string, importer?: string) => {
-        // Simulate Vite's resolve: resolve relative paths based on importer
-        if (importee.startsWith('.')) {
-          const base = importer ? path.dirname(importer) : tmpDir
-          const resolved = path.resolve(base, importee)
-          // Try with .tsx extension if not already present
-          const candidates = [resolved, resolved + '.tsx', resolved + '.ts']
-          for (const candidate of candidates) {
-            try {
-              await fs.access(candidate)
-              return { id: candidate }
-            } catch {
-              // continue
-            }
-          }
-        }
-        return null
-      },
-    }
-    return await transform.call(context, sourceCode, filePath)
+    return await transform.call(resolveContext, sourceCode, filePath)
   }
 
   beforeEach(async () => {
@@ -330,5 +355,116 @@ describe('injectImportingIslands', () => {
 
     expect(result).not.toBeUndefined()
     expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+  })
+
+  it('should skip excluded directories during island detection', async () => {
+    await createFile(
+      'node_modules/pkg/$counter.tsx',
+      `
+      export default function Counter() {
+        return <div>counter</div>
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/from-package.tsx',
+      `
+      import Counter from "../../node_modules/pkg/$counter.tsx"
+      export default function FromPackage() {
+        return <Counter />
+      }
+    `
+    )
+
+    const routePath = await createFile(
+      'app/routes/exclude.tsx',
+      `
+      import FromPackage from "../components/from-package.tsx"
+      export default function Page() {
+        return <FromPackage />
+      }
+    `
+    )
+
+    const routeSource = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPlugin({
+      exclude: ['node_modules'],
+    })
+    const result = await callTransform(plugin, routePath, routeSource)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should not exclude partial directory name matches', async () => {
+    await createFile(
+      'app/components-old/$counter.tsx',
+      `
+      export default function Counter() {
+        return <div>counter</div>
+      }
+    `
+    )
+
+    const routePath = await createFile(
+      'app/routes/partial-match.tsx',
+      `
+      import Counter from "../components-old/$counter.tsx"
+      export default function Page() {
+        return <Counter />
+      }
+    `
+    )
+
+    const routeSource = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPlugin({
+      exclude: ['components'],
+    })
+    const result = await callTransform(plugin, routePath, routeSource)
+
+    expect(result).not.toBeUndefined()
+    expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+  })
+
+  it('should pass injectImportingIslands options through honox', async () => {
+    await createFile(
+      'node_modules/pkg/$counter.tsx',
+      `
+      export default function Counter() {
+        return <div>counter</div>
+      }
+    `
+    )
+
+    await createFile(
+      'app/components/from-package.tsx',
+      `
+      import Counter from "../../node_modules/pkg/$counter.tsx"
+      export default function FromPackage() {
+        return <Counter />
+      }
+    `
+    )
+
+    const routePath = await createFile(
+      'app/routes/honox.tsx',
+      `
+      import FromPackage from "../components/from-package.tsx"
+      export default function Page() {
+        return <FromPackage />
+      }
+    `
+    )
+
+    const routeSource = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPluginFromHonox({
+      injectImportingIslands: {
+        appDir: '/app',
+        exclude: ['node_modules'],
+      },
+    })
+    const result = await callTransform(plugin, routePath, routeSource)
+
+    expect(result).toBeUndefined()
   })
 })

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -3,7 +3,7 @@ import _generate from '@babel/generator'
 import { parse } from '@babel/parser'
 import precinct from 'precinct'
 import { normalizePath } from 'vite'
-import type { Plugin, ResolvedConfig } from 'vite'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { IMPORTING_ISLANDS_ID } from '../constants.js'
@@ -30,14 +30,15 @@ export async function injectImportingIslands(
   let root = ''
   let config: ResolvedConfig
   const resolvedCache = new Map<string, true>()
-  const cache: Record<string, string> = {}
+  const cache = new Map<string, string>()
   const depTreeCache = new Map<string, string[]>()
 
   const walkDependencyTree: (
     baseFile: string,
     resolve: (path: string, importer?: string) => Promise<ResolvedId | null>,
-    dependencyFile?: ResolvedId | string
-  ) => Promise<string[]> = async (baseFile: string, resolve, dependencyFile?) => {
+    dependencyFile?: ResolvedId | string,
+    seen?: Set<string>
+  ) => Promise<string[]> = async (baseFile: string, resolve, dependencyFile?, seen = new Set()) => {
     const depPath = dependencyFile
       ? typeof dependencyFile === 'string'
         ? path.join(path.dirname(baseFile), dependencyFile) + '.tsx'
@@ -48,21 +49,25 @@ export async function injectImportingIslands(
       return depTreeCache.get(depPath)!
     }
 
+    if (seen.has(depPath)) {
+      return [depPath]
+    }
     const deps = [depPath]
+    const nextSeen = new Set(seen).add(depPath)
 
     try {
-      if (!cache[depPath]) {
-        cache[depPath] = (await readFile(depPath, { flag: '' })).toString()
+      if (!cache.has(depPath)) {
+        cache.set(depPath, (await readFile(depPath, { flag: '' })).toString())
       }
 
-      const currentFileDeps = precinct(cache[depPath], {
+      const currentFileDeps = precinct(cache.get(depPath)!, {
         type: 'tsx',
       }) as string[]
 
       const childDeps = await Promise.all(
         currentFileDeps.map(async (file) => {
           const resolvedId = await resolve(file, depPath)
-          return await walkDependencyTree(depPath, resolve, resolvedId ?? file)
+          return await walkDependencyTree(depPath, resolve, resolvedId ?? file, nextSeen)
         })
       )
       deps.push(...childDeps.flat())
@@ -73,8 +78,23 @@ export async function injectImportingIslands(
     return deps
   }
 
+  const clearCaches = () => {
+    resolvedCache.clear()
+    cache.clear()
+    depTreeCache.clear()
+  }
+
   return {
     name: 'inject-importing-islands',
+    buildStart() {
+      clearCaches()
+    },
+    configureServer(server: ViteDevServer) {
+      server.watcher.on('change', clearCaches)
+    },
+    watchChange() {
+      clearCaches()
+    },
     configResolved: async (resolveConfig) => {
       config = resolveConfig
       appPath = path.join(config.root, options?.appDir ?? '/app')

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -29,7 +29,7 @@ export async function injectImportingIslands(
   const islandDir = options?.islandDir ?? '/app/islands'
   let root = ''
   let config: ResolvedConfig
-  const resolvedCache = new Map<string, true>()
+  const resolvedCache = new Map<string, Promise<ResolvedId | null>>()
   const cache = new Map<string, string>()
   const depTreeCache = new Map<string, string[]>()
 
@@ -106,12 +106,15 @@ export async function injectImportingIslands(
       }
 
       const resolve = async (importee: string, importer?: string) => {
-        if (resolvedCache.has(importee)) {
-          return this.resolve(importee)
+        const cacheKey = `${importee}\0${importer ?? ''}`
+        const cached = resolvedCache.get(cacheKey)
+
+        if (cached) {
+          return cached
         }
-        const resolvedId = await this.resolve(importee, importer)
-        // Cache to prevent infinite loops in recursive calls.
-        resolvedCache.set(importee, true)
+
+        const resolvedId = this.resolve(importee, importer) as Promise<ResolvedId | null>
+        resolvedCache.set(cacheKey, resolvedId)
         return resolvedId
       }
 

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -13,9 +13,10 @@ import { matchIslandComponentId } from './utils/path.js'
 // @ts-ignore
 const generate = (_generate.default as typeof _generate) ?? _generate
 
-type InjectImportingIslandsOptions = {
+export type InjectImportingIslandsOptions = {
   appDir?: string
   islandDir?: string
+  exclude?: string[]
 }
 
 type ResolvedId = {
@@ -27,11 +28,19 @@ export async function injectImportingIslands(
 ): Promise<Plugin> {
   let appPath = ''
   const islandDir = options?.islandDir ?? '/app/islands'
+  const excludePatterns = (options?.exclude ?? []).map((dir) => {
+    const segments = normalizePath(dir).split('/').filter(Boolean)
+    return '/' + segments.join('/') + '/'
+  })
   let root = ''
   let config: ResolvedConfig
   const resolvedCache = new Map<string, Promise<ResolvedId | null>>()
   const cache = new Map<string, string>()
   const depTreeCache = new Map<string, string[]>()
+
+  const shouldExclude = (depPath: string) => {
+    return excludePatterns.some((pattern) => depPath.includes(pattern))
+  }
 
   const walkDependencyTree: (
     baseFile: string,
@@ -41,12 +50,16 @@ export async function injectImportingIslands(
   ) => Promise<string[]> = async (baseFile: string, resolve, dependencyFile?, seen = new Set()) => {
     const depPath = dependencyFile
       ? typeof dependencyFile === 'string'
-        ? path.join(path.dirname(baseFile), dependencyFile) + '.tsx'
-        : dependencyFile['id']
-      : baseFile
+        ? normalizePath(path.join(path.dirname(baseFile), dependencyFile) + '.tsx')
+        : normalizePath(dependencyFile['id'])
+      : normalizePath(baseFile)
 
     if (depTreeCache.has(depPath)) {
       return depTreeCache.get(depPath)!
+    }
+
+    if (shouldExclude(depPath)) {
+      return []
     }
 
     if (seen.has(depPath)) {
@@ -101,7 +114,9 @@ export async function injectImportingIslands(
       root = config.root
     },
     async transform(sourceCode, id) {
-      if (!path.resolve(id).startsWith(appPath)) {
+      const normalizedId = normalizePath(path.resolve(id))
+
+      if (!normalizedId.startsWith(normalizePath(appPath))) {
         return
       }
 
@@ -120,7 +135,7 @@ export async function injectImportingIslands(
 
       const hasIslandsImport = (
         await Promise.all(
-          (await walkDependencyTree(id, resolve)).map(async (x) => {
+          (await walkDependencyTree(normalizedId, resolve)).map(async (x) => {
             const rootPath = '/' + path.relative(root, normalizePath(x)).replace(/\\/g, '/')
             return matchIslandComponentId(rootPath, islandDir)
           })

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -29,8 +29,9 @@ export async function injectImportingIslands(
   const islandDir = options?.islandDir ?? '/app/islands'
   let root = ''
   let config: ResolvedConfig
-  const resolvedCache = new Map()
+  const resolvedCache = new Map<string, true>()
   const cache: Record<string, string> = {}
+  const depTreeCache = new Map<string, string[]>()
 
   const walkDependencyTree: (
     baseFile: string,
@@ -42,6 +43,11 @@ export async function injectImportingIslands(
         ? path.join(path.dirname(baseFile), dependencyFile) + '.tsx'
         : dependencyFile['id']
       : baseFile
+
+    if (depTreeCache.has(depPath)) {
+      return depTreeCache.get(depPath)!
+    }
+
     const deps = [depPath]
 
     try {
@@ -60,11 +66,11 @@ export async function injectImportingIslands(
         })
       )
       deps.push(...childDeps.flat())
-      return deps
     } catch {
       // file does not exist or is a directory
-      return deps
     }
+    depTreeCache.set(depPath, deps)
+    return deps
   }
 
   return {
@@ -91,7 +97,7 @@ export async function injectImportingIslands(
 
       const hasIslandsImport = (
         await Promise.all(
-          (await walkDependencyTree(id, resolve)).flat().map(async (x) => {
+          (await walkDependencyTree(id, resolve)).map(async (x) => {
             const rootPath = '/' + path.relative(root, normalizePath(x)).replace(/\\/g, '/')
             return matchIslandComponentId(rootPath, islandDir)
           })


### PR DESCRIPTION
Based on the patch created by @adrianani at https://github.com/honojs/honox/issues/208, I made improvements, including addressing the issue of insufficient cache invalidation.