### PR TITLE
fix(client): make ClientOptions generic over the JSX element type

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -17,13 +17,13 @@ import { filterByPattern } from './utils/filter.js'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FileCallback = () => Promise<Record<string, Promise<any>>>
 
-export type ClientOptions = {
-  hydrate?: Hydrate
-  createElement?: CreateElement
+export type ClientOptions<E = Node> = {
+  hydrate?: Hydrate<E>
+  createElement?: CreateElement<E>
   /**
    * Create "children" attribute of a component from a list of child nodes
    */
-  createChildren?: CreateChildren
+  createChildren?: CreateChildren<E>
   /**
    * Trigger hydration on your own
    */
@@ -35,7 +35,7 @@ export type ClientOptions = {
   island_root?: string
 }
 
-export const createClient = async (options?: ClientOptions) => {
+export const createClient = async <E = Node>(options?: ClientOptions<E>) => {
   const FILES =
     options?.ISLAND_FILES ??
     filterByPattern(
@@ -82,8 +82,8 @@ export const createClient = async (options?: ClientOptions) => {
             let createChildren = options?.createChildren
             if (!createChildren) {
               const { buildCreateChildrenFn } = await import('./runtime')
-              createChildren = buildCreateChildrenFn(
-                createElement as CreateElement,
+              createChildren = buildCreateChildrenFn<E>(
+                createElement as CreateElement<E>,
                 async (name: string) => (await (FILES[`${name}`] as FileCallback)()).default
               )
             }

--- a/src/client/runtime.ts
+++ b/src/client/runtime.ts
@@ -3,12 +3,12 @@ import { COMPONENT_NAME, DATA_HONO_TEMPLATE, DATA_SERIALIZED_PROPS } from '../co
 import type { CreateChildren, CreateElement, HydrateComponent } from '../types.js'
 
 type ImportComponent = (name: string) => Promise<Function | undefined>
-export const buildCreateChildrenFn = (
-  createElement: CreateElement,
+export const buildCreateChildrenFn = <E = Node>(
+  createElement: CreateElement<E>,
   importComponent: ImportComponent
-): CreateChildren => {
+): CreateChildren<E> => {
   let keyIndex = 0
-  const setChildrenFromTemplate = async (props: { children?: Node[] }, element: HTMLElement) => {
+  const setChildrenFromTemplate = async (props: { children?: E[] }, element: HTMLElement) => {
     const maybeTemplate = element.childNodes[element.childNodes.length - 1]
     if (
       maybeTemplate?.nodeName === 'TEMPLATE' &&
@@ -19,10 +19,10 @@ export const buildCreateChildrenFn = (
       )
     }
   }
-  const createElementFromHTMLElement = async (element: HTMLElement) => {
+  const createElementFromHTMLElement = async (element: HTMLElement): Promise<E> => {
     const props = {
       children: await createChildren(element.childNodes),
-    } as Record<string, string> & { children: Node[] }
+    } as Record<string, string> & { children: E[] }
     const attributes = element.attributes
     for (let i = 0; i < attributes.length; i++) {
       props[attributes[i].name] = attributes[i].value
@@ -32,22 +32,22 @@ export const buildCreateChildrenFn = (
       ...props,
     })
   }
-  const createChildren = async (childNodes: NodeListOf<ChildNode>): Promise<Node[]> => {
-    const children = []
+  const createChildren = async (childNodes: NodeListOf<ChildNode>): Promise<E[]> => {
+    const children: E[] = []
     for (let i = 0; i < childNodes.length; i++) {
       const child = childNodes[i] as HTMLElement
       if (child.nodeType === 8) {
         // skip comments
         continue
       } else if (child.nodeType === 3) {
-        // text node
-        children.push(child.textContent)
+        // text node — string is a valid child for hono/jsx and React; cast to E
+        children.push(child.textContent as E)
       } else if (child.nodeName === 'TEMPLATE' && child.id.match(/(?:H|E):\d+/)) {
         const placeholderElement = document.createElement('hono-placeholder')
         placeholderElement.style.display = 'none'
 
-        let resolve: (nodes: Node[]) => void
-        const promise = new Promise<Node[]>((r) => (resolve = r))
+        let resolve: (nodes: E[]) => void
+        const promise = new Promise<E[]>((r) => (resolve = r))
 
         // Suspense: replace content by `replaceWith` when resolved
         // ErrorBoundary: replace content by `replaceWith` when error
@@ -90,8 +90,8 @@ export const buildCreateChildrenFn = (
 
         // if no content available, wait for ErrorBoundary fallback content
         if (fallback.length === 0 && child.id.startsWith('E:')) {
-          let resolve: (nodes: Node[]) => void
-          const promise = new Promise<Node[]>((r) => (resolve = r))
+          let resolve: (nodes: E[]) => void
+          const promise = new Promise<E[]>((r) => (resolve = r))
           fallback = await createElement(Suspense, {
             fallback: [],
             children: [await createElement(() => use(promise), {})],
@@ -132,8 +132,7 @@ export const buildCreateChildrenFn = (
         }
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return children as any
+    return children
   }
 
   return createChildren

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /** JSX */
-export type CreateElement = (type: any, props: any) => Node | Promise<Node>
-export type Hydrate = (children: Node, parent: Element) => void | Promise<void>
-export type CreateChildren = (childNodes: NodeListOf<ChildNode>) => Node[] | Promise<Node[]>
+export type CreateElement<E = Node> = (type: any, props: any) => E | Promise<E>
+export type Hydrate<E = Node> = (children: E, parent: Element) => void | Promise<void>
+export type CreateChildren<E = Node> = (
+  childNodes: NodeListOf<ChildNode>
+) => E[] | Promise<E[]>
 export type HydrateComponent = (doc: {
   querySelectorAll: typeof document.querySelectorAll
 }) => Promise<void>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,7 @@
 /** JSX */
 export type CreateElement<E = Node> = (type: any, props: any) => E | Promise<E>
 export type Hydrate<E = Node> = (children: E, parent: Element) => void | Promise<void>
-export type CreateChildren<E = Node> = (
-  childNodes: NodeListOf<ChildNode>
-) => E[] | Promise<E[]>
+export type CreateChildren<E = Node> = (childNodes: NodeListOf<ChildNode>) => E[] | Promise<E[]>
 export type HydrateComponent = (doc: {
   querySelectorAll: typeof document.querySelectorAll
 }) => Promise<void>


### PR DESCRIPTION
Loosen `CreateElement`, `Hydrate`, `CreateChildren`, and `ClientOptions` with a `<E = Node>` parameter so non-`hono/jsx` runtimes (e.g. React's `createElement` + `hydrateRoot`) can be wired up without the type errors reported in #87. The default keeps backward compatibility for existing `hono/jsx/dom` users.

Also tighten the internal `buildCreateChildrenFn` body to use `E[]` throughout so the body type-checks against the public contract; the former `as any` / `as unknown as CreateChildren<E>` boundary casts are removed. The only remaining assertion is `child.textContent as E` for text nodes, where strings flow through as valid children regardless of the concrete element type. The `fallback` variable keeps its existing `any` typing as that branch mixes single elements with arrays.