### PR TITLE
perf: two performance bugs in `walkDependencyTree`

### DIFF
--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -37,6 +37,7 @@ export async function injectImportingIslands(
   let config: ResolvedConfig
   const resolvedCache = new Map()
   const cache: Record<string, string> = {}
+  const depTreeCache = new Map<string, string[]>()
 
   const walkDependencyTree: (
     baseFile: string,
@@ -48,6 +49,14 @@ export async function injectImportingIslands(
         ? path.join(path.dirname(baseFile), dependencyFile) + '.tsx'
         : dependencyFile['id']
       : baseFile
+
+    // island components are never in node_modules; 
+    // skip to avoid pulling in hundreds of third-party files on every transform call.
+    if (depPath.includes('node_modules')) return []
+
+    // return the already-walked subtree instead of re-walking it.
+    if (depTreeCache.has(depPath)) return depTreeCache.get(depPath)!
+
     const deps = [depPath]
 
     try {
@@ -66,6 +75,7 @@ export async function injectImportingIslands(
         })
       )
       deps.push(...childDeps.flat())
+      depTreeCache.set(depPath, deps)
       return deps
     } catch {
       // file does not exist or is a directory

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -50,7 +50,7 @@ export async function injectImportingIslands(
         : dependencyFile['id']
       : baseFile
 
-    // island components are never in node_modules; 
+    // island components are never in node_modules;
     // skip to avoid pulling in hundreds of third-party files on every transform call.
     if (depPath.includes('node_modules')) return []
 


### PR DESCRIPTION
#### Bug 1 — No subtree memoization (O(N²) walk)

The existing `cache` object only avoids re-reading files from disk. It does **not** prevent re-walking a subtree. When 70 app files all transitively import `utils.ts`, the subtree rooted at `utils.ts` was walked 70 times instead of once.

#### Bug 2 — Recurses into `node_modules`

`precinct` extracts every import string from a file, including third-party ones (`'react'`, `'clsx'`, `'@base-ui/react'`). The walk was resolving and recursing into all of them. An island component that uses React + one UI library can pull in hundreds of `node_modules` files, none of which can ever contain an island component.

