### PR TITLE
fix(island): resolve island dependencies per importer

### DIFF
--- a/src/vite/inject-importing-islands.test.ts
+++ b/src/vite/inject-importing-islands.test.ts
@@ -29,17 +29,25 @@ describe('injectImportingIslands', () => {
   const callTransform = async (
     plugin: ReturnType<typeof setupPlugin> extends Promise<infer T> ? T : never,
     filePath: string,
-    sourceCode: string
+    sourceCode: string,
+    beforeResolve?: (importee: string, importer?: string) => Promise<void>
   ) => {
     const transform = plugin.transform as Function
     const context = {
       resolve: async (importee: string, importer?: string) => {
+        await beforeResolve?.(importee, importer)
         // Simulate Vite's resolve: resolve relative paths based on importer
         if (importee.startsWith('.')) {
           const base = importer ? path.dirname(importer) : tmpDir
           const resolved = path.resolve(base, importee)
           // Try with .tsx extension if not already present
-          const candidates = [resolved, resolved + '.tsx', resolved + '.ts']
+          const candidates = [
+            resolved,
+            resolved + '.tsx',
+            resolved + '.ts',
+            resolved.replace(/\.js$/, '.tsx'),
+            resolved.replace(/\.js$/, '.ts'),
+          ]
           for (const candidate of candidates) {
             try {
               await fs.access(candidate)
@@ -203,6 +211,108 @@ describe('injectImportingIslands', () => {
     const routeSource = await fs.readFile(routePath, 'utf-8')
     const plugin = await setupPlugin()
     const result = await callTransform(plugin, routePath, routeSource)
+
+    expect(result).not.toBeUndefined()
+    expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+  })
+
+  it('should resolve the same relative specifier from different importers', async () => {
+    await createFile(
+      'app/islands/$counter.tsx',
+      'export default function Counter() { return <div>counter</div> }'
+    )
+
+    const routes = await Promise.all(
+      ['route-a', 'route-b'].map(async (route) => {
+        await createFile(
+          'app/routes/' + route + '/pwd.ts',
+          'import Counter from "../../islands/$counter.js"; export { Counter }'
+        )
+        return createFile(
+          'app/routes/' + route + '/index.tsx',
+          'import "./pwd.js"; export default function Page() { return <div /> }'
+        )
+      })
+    )
+
+    const plugin = await setupPlugin()
+    for (const routePath of routes) {
+      const source = await fs.readFile(routePath, 'utf-8')
+      const result = await callTransform(plugin, routePath, source)
+      expect(result).not.toBeUndefined()
+      expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+    }
+  })
+
+  it('should not expose incomplete dependency trees to concurrent transforms', async () => {
+    await createFile(
+      'app/islands/$counter.tsx',
+      'export default function Counter() { return <div>counter</div> }'
+    )
+    await createFile(
+      'app/components/shared.ts',
+      'import Counter from "../islands/$counter.js"; export { Counter }'
+    )
+
+    const routes = await Promise.all(
+      ['route-c', 'route-d'].map(async (route) => {
+        await createFile(
+          'app/routes/' + route + '/pwd.ts',
+          'import { Counter } from "../../components/shared.js"; export { Counter }'
+        )
+        return createFile(
+          'app/routes/' + route + '/index.tsx',
+          'import "./pwd.js"; export default function Page() { return <div /> }'
+        )
+      })
+    )
+
+    let sharedResolveCount = 0
+    let releaseSharedResolves!: () => void
+    const sharedResolvesReady = new Promise<void>((resolve) => {
+      releaseSharedResolves = resolve
+    })
+    const waitForSharedResolves = async (importee: string) => {
+      if (importee !== '../../components/shared.js') return
+      sharedResolveCount++
+      if (sharedResolveCount === routes.length) releaseSharedResolves()
+      await sharedResolvesReady
+    }
+
+    const plugin = await setupPlugin()
+    const results = await Promise.all(
+      routes.map(async (routePath) => {
+        const source = await fs.readFile(routePath, 'utf-8')
+        return callTransform(plugin, routePath, source, waitForSharedResolves)
+      })
+    )
+
+    for (const result of results) {
+      expect(result).not.toBeUndefined()
+      expect(result.code).toContain(IMPORTING_ISLANDS_ID)
+    }
+  })
+  it('should handle circular dependencies', async () => {
+    await createFile(
+      'app/islands/$counter.tsx',
+      'export default function Counter() { return <div>counter</div> }'
+    )
+    await createFile(
+      'app/components/a.tsx',
+      'import B from "./b.js"; export default function A() { return <B /> }'
+    )
+    await createFile(
+      'app/components/b.tsx',
+      'import A from "./a.js"; import Counter from "../islands/$counter.js"; export default function B() { return <><A /><Counter /></> }'
+    )
+    const routePath = await createFile(
+      'app/routes/circular.tsx',
+      'import A from "../components/a.js"; export default function Page() { return <A /> }'
+    )
+
+    const source = await fs.readFile(routePath, 'utf-8')
+    const plugin = await setupPlugin()
+    const result = await callTransform(plugin, routePath, source)
 
     expect(result).not.toBeUndefined()
     expect(result.code).toContain(IMPORTING_ISLANDS_ID)

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -35,8 +35,28 @@ export async function injectImportingIslands(
   const islandDir = options?.islandDir ?? '/app/islands'
   let root = ''
   let config: ResolvedConfig
-  const cache: Record<string, string> = {}
   const depTreeCache = new Map<string, string[]>()
+  // file path -> resolved direct dependencies. Memoized as a promise so that
+  // concurrent transforms resolve each file's imports at most once per build.
+  // Keyed by the importer file path (not the specifier), so relative specifiers
+  // shared across files are always resolved with the correct importer.
+  const fileDepsCache = new Map<string, Promise<(ResolvedId | string)[]>>()
+
+  const getFileDeps = (
+    depPath: string,
+    resolve: (path: string, importer?: string) => Promise<ResolvedId | null>
+  ): Promise<(ResolvedId | string)[]> => {
+    let deps = fileDepsCache.get(depPath)
+    if (!deps) {
+      deps = (async () => {
+        const source = (await readFile(depPath, { flag: '' })).toString()
+        const specifiers = precinct(source, { type: 'tsx' })
+        return Promise.all(specifiers.map(async (file) => (await resolve(file, depPath)) ?? file))
+      })()
+      fileDepsCache.set(depPath, deps)
+    }
+    return deps
+  }
 
   const walkDependencyTree = async (
     baseFile: string,
@@ -67,20 +87,9 @@ export async function injectImportingIslands(
       const deps = [depPath]
 
       try {
-        if (!cache[depPath]) {
-          cache[depPath] = (await readFile(depPath, { flag: '' })).toString()
-        }
+        const resolvedDeps = await getFileDeps(depPath, resolve)
 
-        const currentFileDeps = precinct(cache[depPath], {
-          type: 'tsx',
-        })
-
-        const childDeps = await Promise.all(
-          currentFileDeps.map(async (file) => {
-            const resolvedId = await resolve(file, depPath)
-            return await walk(depPath, resolvedId ?? file)
-          })
-        )
+        const childDeps = await Promise.all(resolvedDeps.map((dep) => walk(depPath, dep)))
         deps.push(...childDeps.flat())
         depTreeCache.set(depPath, deps)
         return deps

--- a/src/vite/inject-importing-islands.ts
+++ b/src/vite/inject-importing-islands.ts
@@ -35,54 +35,63 @@ export async function injectImportingIslands(
   const islandDir = options?.islandDir ?? '/app/islands'
   let root = ''
   let config: ResolvedConfig
-  const resolvedCache = new Map()
   const cache: Record<string, string> = {}
   const depTreeCache = new Map<string, string[]>()
 
-  const walkDependencyTree: (
+  const walkDependencyTree = async (
     baseFile: string,
-    resolve: (path: string, importer?: string) => Promise<ResolvedId | null>,
-    dependencyFile?: ResolvedId | string
-  ) => Promise<string[]> = async (baseFile: string, resolve, dependencyFile?) => {
-    const depPath = dependencyFile
-      ? typeof dependencyFile === 'string'
-        ? path.join(path.dirname(baseFile), dependencyFile) + '.tsx'
-        : dependencyFile['id']
-      : baseFile
+    resolve: (path: string, importer?: string) => Promise<ResolvedId | null>
+  ): Promise<string[]> => {
+    const visited = new Set<string>()
 
-    // island components are never in node_modules;
-    // skip to avoid pulling in hundreds of third-party files on every transform call.
-    if (depPath.includes('node_modules')) return []
+    const walk = async (
+      currentFile: string,
+      dependencyFile?: ResolvedId | string
+    ): Promise<string[]> => {
+      const depPath = dependencyFile
+        ? typeof dependencyFile === 'string'
+          ? path.join(path.dirname(currentFile), dependencyFile) + '.tsx'
+          : dependencyFile['id']
+        : currentFile
 
-    // return the already-walked subtree instead of re-walking it.
-    if (depTreeCache.has(depPath)) return depTreeCache.get(depPath)!
+      // island components are never in node_modules;
+      // skip to avoid pulling in hundreds of third-party files on every transform call.
+      if (depPath.includes('node_modules')) return []
 
-    const deps = [depPath]
+      // return the already-walked subtree instead of re-walking it.
+      if (depTreeCache.has(depPath)) return depTreeCache.get(depPath)!
 
-    try {
-      if (!cache[depPath]) {
-        cache[depPath] = (await readFile(depPath, { flag: '' })).toString()
-      }
+      if (visited.has(depPath)) return []
+      visited.add(depPath)
 
-      const currentFileDeps = precinct(cache[depPath], {
-        type: 'tsx',
-      })
+      const deps = [depPath]
 
-      const childDeps = await Promise.all(
-        currentFileDeps.map(async (file) => {
-          const resolvedId = await resolve(file, depPath)
-          return await walkDependencyTree(depPath, resolve, resolvedId ?? file)
+      try {
+        if (!cache[depPath]) {
+          cache[depPath] = (await readFile(depPath, { flag: '' })).toString()
+        }
+
+        const currentFileDeps = precinct(cache[depPath], {
+          type: 'tsx',
         })
-      )
-      deps.push(...childDeps.flat())
-      depTreeCache.set(depPath, deps)
-      return deps
-    } catch {
-      // file does not exist or is a directory
-      return deps
-    }
-  }
 
+        const childDeps = await Promise.all(
+          currentFileDeps.map(async (file) => {
+            const resolvedId = await resolve(file, depPath)
+            return await walk(depPath, resolvedId ?? file)
+          })
+        )
+        deps.push(...childDeps.flat())
+        depTreeCache.set(depPath, deps)
+        return deps
+      } catch {
+        // file does not exist or is a directory
+        return deps
+      }
+    }
+
+    return walk(baseFile)
+  }
   return {
     name: 'inject-importing-islands',
     configResolved: async (resolveConfig) => {
@@ -95,15 +104,7 @@ export async function injectImportingIslands(
         return
       }
 
-      const resolve = async (importee: string, importer?: string) => {
-        if (resolvedCache.has(importee)) {
-          return this.resolve(importee)
-        }
-        const resolvedId = await this.resolve(importee, importer)
-        // Cache to prevent infinite loops in recursive calls.
-        resolvedCache.set(importee, true)
-        return resolvedId
-      }
+      const resolve = (importee: string, importer?: string) => this.resolve(importee, importer)
 
       const hasIslandsImport = (
         await Promise.all(


### PR DESCRIPTION
closes #374 

## Summary

- Remove `resolvedCache` and always call `this.resolve(importee, importer)` with the importer, so relative specifiers resolve correctly regardless of transform order
  - The cache was originally added in #231 to prevent infinite loops in recursive walks. That role is now covered by a per-walk visited set, which also prevents the exponential re-walking of diamond dependencies (the existing depTreeCache is kept for completed subtrees)

co-author: @kenta-takeuchi - He came up with the strategy for identifying the issues and proposing solutions.