### PR TITLE
refactor(server): use Object.values instead of Object.entries in Link and Script components

### DIFF
--- a/src/server/components/link.tsx
+++ b/src/server/components/link.tsx
@@ -13,7 +13,7 @@ export const Link: FC<Options> = (options) => {
         const MANIFEST = import.meta.glob<{ default: Manifest }>('/dist/.vite/manifest.json', {
           eager: true,
         })
-        for (const [, manifestFile] of Object.entries(MANIFEST)) {
+        for (const manifestFile of Object.values(MANIFEST)) {
           if (manifestFile['default']) {
             manifest = manifestFile['default']
             break

--- a/src/server/components/script.tsx
+++ b/src/server/components/script.tsx
@@ -19,7 +19,7 @@ export const Script = (options: Options): any => {
       const MANIFEST = import.meta.glob<{ default: Manifest }>('/dist/.vite/manifest.json', {
         eager: true,
       })
-      for (const [, manifestFile] of Object.entries(MANIFEST)) {
+      for (const manifestFile of Object.values(MANIFEST)) {
         if (manifestFile['default']) {
           manifest = manifestFile['default']
           break


### PR DESCRIPTION
## Description

`Object.entries` used in `script.tsx` and `link.tsx` did not use the key, so I replaced it with `Object.values`.

 No behavior change.