### PR TITLE
fix(runtime): Fix nested island hydration for named exports and template props

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -88,8 +88,8 @@ export const createClient = async <E = Node>(options?: ClientOptions<E>) => {
             let createChildren = options?.createChildren
             if (!createChildren) {
               const { buildCreateChildrenFn } = await import('./runtime')
-              const importComponent = async (name: string) =>
-                (await (FILES[`${name}`] as FileCallback)()).default
+              const importComponent = async (name: string, exportName = 'default') =>
+                (await (FILES[`${name}`] as FileCallback)())[exportName]
               createChildren = buildCreateChildrenFn<E>(createElement, importComponent)
             }
             props[propKey] = await createChildren(maybeTemplate.content.childNodes)

--- a/src/client/runtime.test.ts
+++ b/src/client/runtime.test.ts
@@ -55,4 +55,43 @@ describe('buildCreateChildrenFn', () => {
       },
     })
   })
+
+  it('should restore multiple named template props', async () => {
+    const createElement = vi.fn((type, props) => ({ type, props }))
+    const NestedIsland = () => null
+    const importComponent = vi.fn(async () => NestedIsland)
+    const createChildren = buildCreateChildrenFn(createElement, importComponent)
+
+    const island = document.createElement('honox-island')
+    island.setAttribute('component-name', '/app/islands/nested.tsx')
+    island.setAttribute('data-serialized-props', '{}')
+    const contentTemplate = document.createElement('template')
+    contentTemplate.setAttribute('data-hono-template', 'content')
+    contentTemplate.innerHTML = '<span>content</span>'
+    const imageTemplate = document.createElement('template')
+    imageTemplate.setAttribute('data-hono-template', 'image')
+    imageTemplate.innerHTML = '<img src="/example.png">'
+    island.append(contentTemplate, imageTemplate)
+
+    const [nestedIsland] = await createChildren([island] as unknown as NodeListOf<ChildNode>)
+
+    expect(nestedIsland).toEqual({
+      type: NestedIsland,
+      props: {
+        key: 3,
+        content: [
+          {
+            type: 'SPAN',
+            props: { children: ['content'], key: expect.any(Number) },
+          },
+        ],
+        image: [
+          {
+            type: 'IMG',
+            props: { children: [], src: '/example.png', key: expect.any(Number) },
+          },
+        ],
+      },
+    })
+  })
 })

--- a/src/client/runtime.test.ts
+++ b/src/client/runtime.test.ts
@@ -18,4 +18,41 @@ describe('buildCreateChildrenFn', () => {
       key: 2,
     })
   })
+
+  it('should restore nested island exports and named template props', async () => {
+    const createElement = vi.fn((type, props) => ({ type, props }))
+    const NestedIsland = () => null
+    const importComponent = vi.fn(async (name, exportName) => {
+      expect(name).toBe('/app/islands/nested.tsx')
+      expect(exportName).toBe('NestedIsland')
+      return NestedIsland
+    })
+    const createChildren = buildCreateChildrenFn(createElement, importComponent)
+
+    const island = document.createElement('honox-island')
+    island.setAttribute('component-name', '/app/islands/nested.tsx')
+    island.setAttribute('component-export', 'NestedIsland')
+    island.setAttribute('data-serialized-props', '{"label":"example"}')
+    const contentTemplate = document.createElement('template')
+    contentTemplate.setAttribute('data-hono-template', 'content')
+    contentTemplate.innerHTML = '<span>example</span>'
+    island.append(contentTemplate)
+
+    const [nestedIsland] = await createChildren([island] as unknown as NodeListOf<ChildNode>)
+
+    expect(importComponent).toHaveBeenCalledWith('/app/islands/nested.tsx', 'NestedIsland')
+    expect(nestedIsland).toEqual({
+      type: NestedIsland,
+      props: {
+        key: 2,
+        label: 'example',
+        content: [
+          {
+            type: 'SPAN',
+            props: { children: ['example'], key: 1 },
+          },
+        ],
+      },
+    })
+  })
 })

--- a/src/client/runtime.ts
+++ b/src/client/runtime.ts
@@ -14,10 +14,7 @@ export const buildCreateChildrenFn = <E = Node>(
   importComponent: ImportComponent
 ): CreateChildren<E> => {
   let keyIndex = 0
-  const setChildrenFromTemplate = async (
-    props: Record<string, unknown>,
-    element: Element
-  ) => {
+  const setChildrenFromTemplate = async (props: Record<string, unknown>, element: Element) => {
     const maybeTemplate = element.childNodes[element.childNodes.length - 1]
     if (isTemplateElement(maybeTemplate)) {
       const propKey = maybeTemplate.getAttribute(DATA_HONO_TEMPLATE)

--- a/src/client/runtime.ts
+++ b/src/client/runtime.ts
@@ -1,24 +1,29 @@
 import { Suspense, use } from 'hono/jsx/dom'
-import { COMPONENT_NAME, DATA_HONO_TEMPLATE, DATA_SERIALIZED_PROPS } from '../constants.js'
+import {
+  COMPONENT_EXPORT,
+  COMPONENT_NAME,
+  DATA_HONO_TEMPLATE,
+  DATA_SERIALIZED_PROPS,
+} from '../constants.js'
 import type { CreateChildren, CreateElement, HydrateComponent } from '../types.js'
 import { isComment, isElement, isProperText, isTemplateElement } from './utils/dom.js'
 
-type ImportComponent = (name: string) => Promise<Function | undefined>
+type ImportComponent = (name: string, exportName?: string) => Promise<Function | undefined>
 export const buildCreateChildrenFn = <E = Node>(
   createElement: CreateElement<E>,
   importComponent: ImportComponent
 ): CreateChildren<E> => {
   let keyIndex = 0
   const setChildrenFromTemplate = async (
-    props: { children?: (string | E)[] },
+    props: Record<string, unknown>,
     element: Element
   ) => {
     const maybeTemplate = element.childNodes[element.childNodes.length - 1]
-    if (
-      isTemplateElement(maybeTemplate) &&
-      maybeTemplate.getAttribute(DATA_HONO_TEMPLATE) !== null
-    ) {
-      props.children = await createChildren(maybeTemplate.content.childNodes)
+    if (isTemplateElement(maybeTemplate)) {
+      const propKey = maybeTemplate.getAttribute(DATA_HONO_TEMPLATE)
+      if (propKey !== null) {
+        props[propKey] = await createChildren(maybeTemplate.content.childNodes)
+      }
     }
   }
   const createElementFromDom = async (element: Element): Promise<E> => {
@@ -117,7 +122,8 @@ export const buildCreateChildrenFn = <E = Node>(
         let component: Function | undefined = undefined
         const componentName = child.getAttribute(COMPONENT_NAME)
         if (componentName) {
-          component = await importComponent(componentName)
+          const exportName = child.getAttribute(COMPONENT_EXPORT) || 'default'
+          component = await importComponent(componentName, exportName)
         }
         if (component) {
           const props = JSON.parse(child.getAttribute(DATA_SERIALIZED_PROPS) || '{}')

--- a/src/client/runtime.ts
+++ b/src/client/runtime.ts
@@ -15,11 +15,12 @@ export const buildCreateChildrenFn = <E = Node>(
 ): CreateChildren<E> => {
   let keyIndex = 0
   const setChildrenFromTemplate = async (props: Record<string, unknown>, element: Element) => {
-    const maybeTemplate = element.childNodes[element.childNodes.length - 1]
-    if (isTemplateElement(maybeTemplate)) {
-      const propKey = maybeTemplate.getAttribute(DATA_HONO_TEMPLATE)
-      if (propKey !== null) {
-        props[propKey] = await createChildren(maybeTemplate.content.childNodes)
+    for (const child of element.childNodes) {
+      if (isTemplateElement(child)) {
+        const propKey = child.getAttribute(DATA_HONO_TEMPLATE)
+        if (propKey !== null) {
+          props[propKey] = await createChildren(child.content.childNodes)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fix hydration for islands rendered inside another island through a component prop.

An island is normally hydrated from a top-level `<honox-island>` element. However,
when an island component is passed as an element prop to another island, HonoX serializes that prop into a `<template data-hono-template="...">` inside the parent island.

For example, the server-rendered output may look like this:

```html
<honox-island component-name="/app/islands/parent.tsx">
  <template data-hono-template="content">
    <honox-island
      component-name="/app/islands/child.tsx"
      component-export="Child"
      data-serialized-props="{}"
    >
      ...
    </honox-island>
  </template>
</honox-island>
```

During client-side hydration, the parent island restores the template contents and reconstructs the child island. This path currently differs from the top-level island hydration path in two ways:

1. It always loads the `default` export, ignoring `component-export`.
2. It restores template contents to `props.children`, even whe `data-hono-template` specifies another prop name.

As a result, nested islands using named exports may not be hydrated, and element props such as `content`, `image`, or other named template props may be lost during hydration.

## Changes

- Pass the nested island's `component-export` value to the component loader.
- Resolve the requested export, falling back to `default`.
- Restore template contents to the prop named by `data-hono-template`.
- Add a generic test covering named nested island exports and named template props.
